### PR TITLE
JPMML Integration Tests + Random Forest Classifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,7 @@ docs/_build/
 
 # PyBuilder
 target/
+
+#java/intellij stuff
+*.iml
+*.class

--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@ A library that allows serialization of SciKit-Learn estimators into PMML
 - DecisionTreeClassifier
 - DecisionTreeRegressor
 - GradientBoostingClassifier
+- RandomForestClassifier

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ scikit-learn>=0.15.2
 pandas>=0.15.0
 scipy>=0.15.1
 pytest>=2.7.0
-
+lxml>=3.4.2

--- a/sklearn_pmml/convert/model.py
+++ b/sklearn_pmml/convert/model.py
@@ -64,6 +64,23 @@ class EstimatorConverter(object):
                     data_field.append(pmml.Value(value_=v))
         return dd
 
+    def output(self):
+        output = pmml.Output()
+        output_field = pmml.OutputField(name=self.context.schemas[self.SCHEMA_OUTPUT][0], feature='predictedValue')
+        output.append(output_field)
+        for output_variable in self.context.schemas[self.SCHEMA_OUTPUT]:
+            if isinstance(output_variable, CategoricalFeature):
+                for output_value in output_variable.value_list:
+                    output_field = pmml.OutputField(name='Probability_' + str(output_value),
+                                                    optype='continuous',
+                                                    dataType='double',
+                                                    feature='probability',
+                                                    targetField=str(output_variable),
+                                                    value_=str(output_value))
+                    output.append(output_field)
+        return output
+
+
     def transformation_dictionary(self):
         """
         Build a transformation dictionary and return a TransformationDictionary element

--- a/sklearn_pmml/convert/random_forest.py
+++ b/sklearn_pmml/convert/random_forest.py
@@ -1,0 +1,44 @@
+__author__ = 'evancox'
+
+
+from sklearn.ensemble import RandomForestClassifier
+from sklearn_pmml.convert.model import EstimatorConverter
+from sklearn_pmml.convert.tree import DecisionTreeConverter
+from sklearn_pmml.convert.utils import estimator_to_converter
+
+import sklearn_pmml.pmml as pmml
+
+class RandomForestClassifierConverter(EstimatorConverter):
+    def __init__(self, estimator, context):
+        super(RandomForestClassifierConverter, self).__init__(estimator, context, self.MODE_CLASSIFICATION)
+        assert isinstance(estimator, RandomForestClassifier), \
+            'This converter can only process RandomForestClassifier instances'
+        assert len(context.schemas[self.SCHEMA_OUTPUT]) == 1, 'Only one-label classification is supported'
+
+    def model(self, verification_data=None):
+        mining_model = pmml.MiningModel(functionName=self.MODE_CLASSIFICATION)
+        mining_model.append(self.mining_schema())
+        mining_model.append(self.output())
+        mining_model.append(self.segmentation())
+        if verification_data is not None:
+            mining_model.append(self.model_verification(verification_data))
+        return mining_model
+
+
+    def segmentation(self):
+        """
+        Build a segmentation (sequence of estimators)
+        :return: Segmentation element
+        """
+        segmentation = pmml.Segmentation(multipleModelMethod="majorityVote")
+
+        for index, est in enumerate(self.estimator.estimators_):
+            s = pmml.Segment(id=index)
+            s.append(pmml.True_())
+            s.append(DecisionTreeConverter(est, self.context, self.MODE_CLASSIFICATION)._model())
+            segmentation.append(s)
+
+        return segmentation
+
+
+estimator_to_converter[RandomForestClassifier] = RandomForestClassifierConverter

--- a/sklearn_pmml/convert/test/jpmml-csv-evaluator/pom.xml
+++ b/sklearn_pmml/convert/test/jpmml-csv-evaluator/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>sklearn.pmml.jpmml</groupId>
+    <artifactId>jpmml-csv-evaluator</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.jpmml</groupId>
+            <artifactId>pmml-evaluator</artifactId>
+            <!-- DO NOT UPGRADE: newer versions are licensed under AGPL -->
+            <version>1.0.22</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jpmml</groupId>
+            <artifactId>pmml-model</artifactId>
+            <!-- OK to upgrade this one: released under BSD 3-clause. Must not upgrade pmml-evaluator.  -->
+            <version>1.0.22</version>
+        </dependency>
+
+        <dependency>
+            <groupId>net.sf.supercsv</groupId>
+            <artifactId>super-csv</artifactId>
+            <version>2.0.1</version>
+        </dependency>
+
+    </dependencies>
+
+
+
+    <build>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.0</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/sklearn_pmml/convert/test/jpmml-csv-evaluator/src/main/java/sklearn/pmml/jpmml/JPMMLCSVEvaluator.java
+++ b/sklearn_pmml/convert/test/jpmml-csv-evaluator/src/main/java/sklearn/pmml/jpmml/JPMMLCSVEvaluator.java
@@ -1,0 +1,148 @@
+package sklearn.pmml.jpmml;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+import com.google.common.collect.Sets;
+import org.dmg.pmml.FieldName;
+import org.dmg.pmml.IOUtil;
+import org.dmg.pmml.PMML;
+import org.jpmml.evaluator.FieldValue;
+import org.jpmml.evaluator.Evaluator;
+import org.jpmml.evaluator.ModelEvaluator;
+import org.jpmml.evaluator.ModelEvaluatorFactory;
+import org.jpmml.manager.PMMLManager;
+import org.supercsv.io.CsvMapReader;
+import org.supercsv.io.CsvMapWriter;
+import org.supercsv.prefs.CsvPreference;
+import org.xml.sax.SAXException;
+
+import javax.xml.bind.JAXBException;
+
+import java.io.FileInputStream;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Created by evancox on 7/23/15.
+ */
+public class JPMMLCSVEvaluator
+{
+    private static final Logger logger = Logger.getLogger(JPMMLCSVEvaluator.class.getCanonicalName());
+
+    static PMML pmmlFromXml(final InputStream is)
+    {
+        try
+        {
+            return IOUtil.unmarshal(is);
+        }
+        catch (SAXException | JAXBException e)
+        {
+            throw new RuntimeException("Error reading PMML.", e);
+        }
+    }
+
+    static Evaluator evaluatorFromPmml(final PMML pmml)
+    {
+        final PMMLManager pmmlManager = new PMMLManager(pmml);
+        final ModelEvaluator<?> modelEvaluator = (ModelEvaluator<?>) pmmlManager.getModelManager(null, ModelEvaluatorFactory.getInstance());
+
+        return modelEvaluator;
+    }
+
+    static Evaluator evaluatorFromXml(final InputStream is)
+    {
+        // Adapted from:
+        //   * https://github.com/jpmml/jpmml/blob/master/README.md
+        //   * https://github.com/jpmml/jpmml-example/blob/master/src/main/java/org/jpmml/example/CsvEvaluationExample.java
+        return evaluatorFromPmml(pmmlFromXml(is));
+    }
+
+    static List<Map<FieldName, ?>> getPredictions(Evaluator evaluator, String csvFeaturesFile) throws IOException
+    {
+        try (final CsvMapReader csvMapReader = new CsvMapReader(new FileReader(csvFeaturesFile), CsvPreference.STANDARD_PREFERENCE)) {
+            final String[] headers = csvMapReader.getHeader(true);
+            final Map<String, FieldName> fieldNameMap = new HashMap<>(headers.length);
+            for (String header : Arrays.asList(headers))
+            {
+                fieldNameMap.put(header, new FieldName(header));
+            }
+
+            Map<String, String> rawCsvMap;
+            final List<Map<FieldName, ?>> predictions = Lists.newArrayList();
+            while ((rawCsvMap = csvMapReader.read(headers)) != null) {
+                final Map<FieldName, FieldValue> featureMap = Maps.newHashMapWithExpectedSize(rawCsvMap.size());
+                for (Map.Entry<String, String> keyValue : rawCsvMap.entrySet())
+                {
+                    final FieldName fieldName = fieldNameMap.get(keyValue.getKey());
+                    final FieldValue fieldValue = evaluator.prepare(fieldName, keyValue.getValue());
+                    featureMap.put(fieldName, fieldValue);
+                }
+                predictions.add(evaluator.evaluate(featureMap));
+            }
+            return predictions;
+        }
+    }
+
+    static void writePredictions(Evaluator evaluator, List<Map<FieldName, ?>> predictions, String outputFile) throws IOException
+    {
+        final int outputFieldCount = evaluator.getOutputFields().size();
+        final Set<FieldName> outputFields = Sets.newHashSetWithExpectedSize(outputFieldCount);
+        final String[] header = new String[outputFieldCount];
+        int index = 0;
+        for (FieldName fieldName : evaluator.getOutputFields())
+        {
+            outputFields.add(fieldName);
+            header[index++] = fieldName.toString();
+        }
+
+        try (final CsvMapWriter csvMapWriter = new CsvMapWriter(new FileWriter(outputFile), CsvPreference.STANDARD_PREFERENCE))
+        {
+            csvMapWriter.writeHeader(header);
+            for (Map<FieldName, ?> prediction : predictions) {
+
+                final Map<String, Object> row = Maps.newHashMapWithExpectedSize(prediction.size());
+                for (Map.Entry<FieldName, ?> keyValue : prediction.entrySet())
+                {
+                    row.put(keyValue.getKey().toString(), keyValue.getValue());
+                }
+                csvMapWriter.write(row, header);
+            }
+        }
+    }
+
+    public static void main(String[] args)
+    {
+        if (args.length != 3)
+        {
+            throw new RuntimeException("Expected PMML file, feature data, and output predictions file");
+        }
+        final String pmmlFile = args[0];
+        final String csvFeaturesFile = args[1];
+        final String outputFile = args[2];
+        try
+        {
+            Evaluator evaluator = evaluatorFromXml(new FileInputStream(pmmlFile));
+            final List<Map<FieldName, ?>> predictions = getPredictions(evaluator, csvFeaturesFile);
+            writePredictions(evaluator, predictions, outputFile);
+            logger.info(String.format("Wrote %d predictions from %s to %s", predictions.size(), csvFeaturesFile, outputFile));
+        }
+        catch (IOException ex)
+        {
+            logger.log(Level.SEVERE, "IOException", ex);
+            System.exit(1);
+        }
+
+
+    }
+
+}

--- a/sklearn_pmml/convert/test/jpmml_test.py
+++ b/sklearn_pmml/convert/test/jpmml_test.py
@@ -5,6 +5,7 @@ import hashlib
 import os
 import shutil
 import subprocess
+import logging
 from lxml import etree
 
 from sklearn_pmml.convert import TransformationContext
@@ -14,6 +15,8 @@ from sklearn_pmml.convert.features import *
 _TARGET = [0, 1, 2]
 _TARGET_NAME = 'y'
 _TEST_DIR = 'jpmml_test_data'
+
+logging.basicConfig(format='%(asctime)s %(message)s')
 
 #Adapted from http://stackoverflow.com/questions/1724693/find-a-file-in-python
 def find_file_or_dir(name):
@@ -25,9 +28,28 @@ def find_file_or_dir(name):
 class JPMMLTest():
 
     @staticmethod
+    def can_run():
+        try:
+            subprocess.check_call(['java', '-version'])
+        except OSError:
+            logging.warning("Couldn't find java to run JPMML integration tests")
+            return False
+
+        try:
+            subprocess.check_call(['mvn', '-version'])
+        except OSError:
+            logging.warning("Couldn't find java to run JPMML integration tests")
+            return False
+
+        return True
+
+
+
+    @staticmethod
     def init_jpmml():
         result = subprocess.call(['mvn', '-q', 'clean', 'package', '-f', find_file_or_dir('jpmml-csv-evaluator')])
         assert result == 0, "Unable to package jpmml csv evaluator"
+        return True
 
     #taken from http://stackoverflow.com/questions/18159221/remove-namespace-and-prefix-from-xml-in-python-using-lxml
     @staticmethod
@@ -52,6 +74,37 @@ class JPMMLTest():
     def output(self):
         raise NotImplementedError()
 
+    def setup_jpmml_test(self):
+        if not JPMMLTest.can_run():
+            logging.warning("Can't run regression test, java and/or maven not installed")
+            return None
+
+        if os.path.exists(_TEST_DIR):
+            shutil.rmtree(_TEST_DIR)
+        os.makedirs(_TEST_DIR)
+
+        #evancox This is a hack to allow us to mark the version down as 4.1 so we can run with the BSD version of JPMML rather than the AGPL one
+        xml = self.converter.pmml().toxml("utf-8")
+        pmml = etree.fromstring(xml)
+        pmml.set('version', '4.1')
+        JPMMLTest.remove_namespace(pmml, 'http://www.dmg.org/PMML-4_2')
+        xml = etree.tostring(pmml, pretty_print=True)
+        xml = xml.replace('http://www.dmg.org/PMML-4_2', 'http://www.dmg.org/PMML-4_1')
+
+        pmml_hash = hashlib.md5(xml).hexdigest()
+        pmml_file_path = os.path.join(_TEST_DIR, pmml_hash + '.pmml')
+        with open(pmml_file_path, 'w') as pmml_file:
+            pmml_file.write(xml)
+
+        input_file_path = os.path.join(_TEST_DIR, pmml_hash + '_input.csv')
+        self.x.to_csv(input_file_path,index=False)
+        target_file_path = os.path.join(_TEST_DIR, pmml_hash + '_output.csv')
+
+        java_args = ' '.join([os.path.abspath(pmml_file_path), os.path.abspath(input_file_path), os.path.abspath(target_file_path)])
+        result = subprocess.call(['mvn', 'exec:java', '-q', '-f', find_file_or_dir('jpmml-csv-evaluator'), '-Dexec.mainClass=sklearn.pmml.jpmml.JPMMLCSVEvaluator', '-Dexec.args=' + java_args])
+        self.assertEqual(result, 0, 'Executing jpmml evaluator returned non zero result')
+        return pd.read_csv(target_file_path)
+
     def init_data(self):
         np.random.seed(12323444556)
         self.x = pd.DataFrame(np.random.randn(500, 10))
@@ -75,31 +128,10 @@ class JPMMLRegressionTest(JPMMLTest):
         return IntegerNumericFeature(_TARGET_NAME, _TARGET)
 
     def test_regression(self):
-        if os.path.exists(_TEST_DIR):
-            shutil.rmtree(_TEST_DIR)
-        os.makedirs(_TEST_DIR)
+        jpmml_predictions = self.setup_jpmml_test()
+        if jpmml_predictions is None:
+            return
 
-        #evancox This is a hack to allow us to mark the version down as 4.1 so we can run with the BSD version of JPMML rather than the AGPL one
-        xml = self.converter.pmml().toxml("utf-8")
-        pmml = etree.fromstring(xml)
-        pmml.set('version', '4.1')
-        JPMMLTest.remove_namespace(pmml, 'http://www.dmg.org/PMML-4_2')
-        xml = etree.tostring(pmml, pretty_print=True)
-        xml = xml.replace('http://www.dmg.org/PMML-4_2', 'http://www.dmg.org/PMML-4_1')
-
-        pmml_hash = hashlib.md5(xml).hexdigest()
-        pmml_file_path = os.path.join(_TEST_DIR, pmml_hash + '.pmml')
-        with open(pmml_file_path, 'w') as pmml_file:
-            pmml_file.write(xml)
-
-        input_file_path = os.path.join(_TEST_DIR, pmml_hash + '_input.csv')
-        self.x.to_csv(input_file_path,index=False)
-        target_file_path = os.path.join(_TEST_DIR, pmml_hash + '_output.csv')
-
-        java_args = ' '.join([os.path.abspath(pmml_file_path), os.path.abspath(input_file_path), os.path.abspath(target_file_path)])
-        result = subprocess.call(['mvn', 'exec:java', '-q', '-f', find_file_or_dir('jpmml-csv-evaluator'), '-Dexec.mainClass=sklearn.pmml.jpmml.JPMMLCSVEvaluator', '-Dexec.args=' + java_args])
-        self.assertEqual(result, 0, 'Executing jpmml evaluator returned non zero result')
-        jpmml_predictions = pd.read_csv(target_file_path)
         sklearn_predictions = pd.DataFrame({_TARGET_NAME:self.converter.estimator.predict(self.x)})
         diff = jpmml_predictions[_TARGET_NAME] - sklearn_predictions[_TARGET_NAME]
         self.assertTrue(np.all(np.abs(diff) < .001))
@@ -112,31 +144,11 @@ class JPMMLClassificationTest(JPMMLTest):
         return IntegerCategoricalFeature(_TARGET_NAME, _TARGET)
 
     def test_classification(self):
-        if os.path.exists(_TEST_DIR):
-            shutil.rmtree(_TEST_DIR)
-        os.makedirs(_TEST_DIR)
 
-        #evancox This is a hack to allow us to mark the version down as 4.1 so we can run with the BSD version of JPMML rather than the AGPL one
-        xml = self.converter.pmml().toxml("utf-8")
-        pmml = etree.fromstring(xml)
-        pmml.set('version', '4.1')
-        JPMMLTest.remove_namespace(pmml, 'http://www.dmg.org/PMML-4_2')
-        xml = etree.tostring(pmml, pretty_print=True)
-        xml = xml.replace('http://www.dmg.org/PMML-4_2', 'http://www.dmg.org/PMML-4_1')
+        jpmml_predictions = self.setup_jpmml_test()
+        if jpmml_predictions is None:
+            return
 
-        pmml_hash = hashlib.md5(xml).hexdigest()
-        pmml_file_path = os.path.join(_TEST_DIR, pmml_hash + '.pmml')
-        with open(pmml_file_path, 'w') as pmml_file:
-            pmml_file.write(xml)
-
-        input_file_path = os.path.join(_TEST_DIR, pmml_hash + '_input.csv')
-        self.x.to_csv(input_file_path,index=False)
-        target_file_path = os.path.join(_TEST_DIR, pmml_hash + '_output.csv')
-
-        java_args = ' '.join([os.path.abspath(pmml_file_path), os.path.abspath(input_file_path), os.path.abspath(target_file_path)])
-        result = subprocess.call(['mvn', 'exec:java', '-q', '-f', find_file_or_dir('jpmml-csv-evaluator'), '-Dexec.mainClass=sklearn.pmml.jpmml.JPMMLCSVEvaluator', '-Dexec.args=' + java_args])
-        self.assertEqual(result, 0, 'Executing jpmml evaluator returned non zero result')
-        jpmml_predictions = pd.read_csv(target_file_path)
         raw_sklearn_predictions = self.converter.estimator.predict_proba(self.x)
         prob_outputs = ['Probability_' + str(clazz) for clazz in self.converter.estimator.classes_]
         sklearn_predictions = pd.DataFrame(columns=prob_outputs)

--- a/sklearn_pmml/convert/test/jpmml_test.py
+++ b/sklearn_pmml/convert/test/jpmml_test.py
@@ -1,0 +1,148 @@
+__author__ = 'evancox'
+
+import numpy as np
+import hashlib
+import os
+import shutil
+import subprocess
+from lxml import etree
+
+from sklearn_pmml.convert import TransformationContext
+from sklearn_pmml.convert.features import *
+
+
+_TARGET = [0, 1, 2]
+_TARGET_NAME = 'y'
+_TEST_DIR = 'jpmml_test_data'
+
+#Adapted from http://stackoverflow.com/questions/1724693/find-a-file-in-python
+def find_file_or_dir(name):
+    for root, dirs, files in os.walk('.'):
+        if name in files or name in dirs:
+            return os.path.join(root, name)
+
+
+class JPMMLTest():
+
+    @staticmethod
+    def init_jpmml():
+        result = subprocess.call(['mvn', '-q', 'clean', 'package', '-f', find_file_or_dir('jpmml-csv-evaluator')])
+        assert result == 0, "Unable to package jpmml csv evaluator"
+
+    #taken from http://stackoverflow.com/questions/18159221/remove-namespace-and-prefix-from-xml-in-python-using-lxml
+    @staticmethod
+    def remove_namespace(doc, namespace):
+        ns = u'{%s}' % namespace
+        nsl = len(ns)
+        for elem in doc.getiterator():
+            if elem.tag.startswith(ns):
+                elem.tag = elem.tag[nsl:]
+
+    @property
+    def model(self):
+        if self._model is None:
+            raise NotImplementedError()
+        return self._model
+
+    @model.setter
+    def model(self, model):
+        self._model = model
+
+    @property
+    def output(self):
+        raise NotImplementedError()
+
+    def init_data(self):
+        np.random.seed(12323444556)
+        self.x = pd.DataFrame(np.random.randn(500, 10))
+        self.y = pd.DataFrame({_TARGET_NAME:[np.random.choice([0, 1, 2]) for _ in range(self.x.shape[0])]})
+        self._model.fit(self.x, np.ravel(self.y))
+        self.ctx = TransformationContext(
+            input=[RealNumericFeature(col) for col in list(self.x)],
+            derived=[],
+            model=[RealNumericFeature(col) for col in list(self.x)],
+            output=[self.output]
+        )
+
+
+
+
+
+class JPMMLRegressionTest(JPMMLTest):
+
+    @property
+    def output(self):
+        return IntegerNumericFeature(_TARGET_NAME, _TARGET)
+
+    def test_regression(self):
+        if os.path.exists(_TEST_DIR):
+            shutil.rmtree(_TEST_DIR)
+        os.makedirs(_TEST_DIR)
+
+        #evancox This is a hack to allow us to mark the version down as 4.1 so we can run with the BSD version of JPMML rather than the AGPL one
+        xml = self.converter.pmml().toxml("utf-8")
+        pmml = etree.fromstring(xml)
+        pmml.set('version', '4.1')
+        JPMMLTest.remove_namespace(pmml, 'http://www.dmg.org/PMML-4_2')
+        xml = etree.tostring(pmml, pretty_print=True)
+        xml = xml.replace('http://www.dmg.org/PMML-4_2', 'http://www.dmg.org/PMML-4_1')
+
+        pmml_hash = hashlib.md5(xml).hexdigest()
+        pmml_file_path = os.path.join(_TEST_DIR, pmml_hash + '.pmml')
+        with open(pmml_file_path, 'w') as pmml_file:
+            pmml_file.write(xml)
+
+        input_file_path = os.path.join(_TEST_DIR, pmml_hash + '_input.csv')
+        self.x.to_csv(input_file_path,index=False)
+        target_file_path = os.path.join(_TEST_DIR, pmml_hash + '_output.csv')
+
+        java_args = ' '.join([os.path.abspath(pmml_file_path), os.path.abspath(input_file_path), os.path.abspath(target_file_path)])
+        result = subprocess.call(['mvn', 'exec:java', '-q', '-f', find_file_or_dir('jpmml-csv-evaluator'), '-Dexec.mainClass=sklearn.pmml.jpmml.JPMMLCSVEvaluator', '-Dexec.args=' + java_args])
+        self.assertEqual(result, 0, 'Executing jpmml evaluator returned non zero result')
+        jpmml_predictions = pd.read_csv(target_file_path)
+        sklearn_predictions = pd.DataFrame({_TARGET_NAME:self.converter.estimator.predict(self.x)})
+        diff = jpmml_predictions[_TARGET_NAME] - sklearn_predictions[_TARGET_NAME]
+        self.assertTrue(np.all(np.abs(diff) < .001))
+
+
+class JPMMLClassificationTest(JPMMLTest):
+
+    @property
+    def output(self):
+        return IntegerCategoricalFeature(_TARGET_NAME, _TARGET)
+
+    def test_classification(self):
+        if os.path.exists(_TEST_DIR):
+            shutil.rmtree(_TEST_DIR)
+        os.makedirs(_TEST_DIR)
+
+        #evancox This is a hack to allow us to mark the version down as 4.1 so we can run with the BSD version of JPMML rather than the AGPL one
+        xml = self.converter.pmml().toxml("utf-8")
+        pmml = etree.fromstring(xml)
+        pmml.set('version', '4.1')
+        JPMMLTest.remove_namespace(pmml, 'http://www.dmg.org/PMML-4_2')
+        xml = etree.tostring(pmml, pretty_print=True)
+        xml = xml.replace('http://www.dmg.org/PMML-4_2', 'http://www.dmg.org/PMML-4_1')
+
+        pmml_hash = hashlib.md5(xml).hexdigest()
+        pmml_file_path = os.path.join(_TEST_DIR, pmml_hash + '.pmml')
+        with open(pmml_file_path, 'w') as pmml_file:
+            pmml_file.write(xml)
+
+        input_file_path = os.path.join(_TEST_DIR, pmml_hash + '_input.csv')
+        self.x.to_csv(input_file_path,index=False)
+        target_file_path = os.path.join(_TEST_DIR, pmml_hash + '_output.csv')
+
+        java_args = ' '.join([os.path.abspath(pmml_file_path), os.path.abspath(input_file_path), os.path.abspath(target_file_path)])
+        result = subprocess.call(['mvn', 'exec:java', '-q', '-f', find_file_or_dir('jpmml-csv-evaluator'), '-Dexec.mainClass=sklearn.pmml.jpmml.JPMMLCSVEvaluator', '-Dexec.args=' + java_args])
+        self.assertEqual(result, 0, 'Executing jpmml evaluator returned non zero result')
+        jpmml_predictions = pd.read_csv(target_file_path)
+        raw_sklearn_predictions = self.converter.estimator.predict_proba(self.x)
+        prob_outputs = ['Probability_' + str(clazz) for clazz in self.converter.estimator.classes_]
+        sklearn_predictions = pd.DataFrame(columns=prob_outputs)
+        for index, prediction in enumerate(raw_sklearn_predictions):
+            sklearn_predictions.loc[index] = list(prediction)
+        self.assertTrue(np.all(jpmml_predictions[prob_outputs] == sklearn_predictions))
+
+
+

--- a/sklearn_pmml/convert/test/jpmml_test.py
+++ b/sklearn_pmml/convert/test/jpmml_test.py
@@ -106,7 +106,7 @@ class JPMMLTest():
         return pd.read_csv(target_file_path)
 
     def init_data(self):
-        np.random.seed(12323444556)
+        np.random.seed(12363)
         self.x = pd.DataFrame(np.random.randn(500, 10))
         self.y = pd.DataFrame({_TARGET_NAME:[np.random.choice([0, 1, 2]) for _ in range(self.x.shape[0])]})
         self._model.fit(self.x, np.ravel(self.y))

--- a/sklearn_pmml/convert/test/test_decisionTreeClassifierConverter.py
+++ b/sklearn_pmml/convert/test/test_decisionTreeClassifierConverter.py
@@ -123,8 +123,7 @@ class TestDecisionTreeClassificationJPMMLParity(TestCase, JPMMLClassificationTes
 
     def setUp(self):
         self.model = DecisionTreeClassifier()
-        super(TestDecisionTreeClassificationJPMMLParity, self).init_data()
-        super(TestDecisionTreeClassificationJPMMLParity, self).setUp()
+        self.init_data()
         self.converter = DecisionTreeConverter(
             estimator=self.model,
             context=self.ctx,
@@ -135,8 +134,7 @@ class TestDecisionTreeRegressionJPMMLParity(TestCase, JPMMLRegressionTest):
 
     def setUp(self):
         self.model = DecisionTreeRegressor()
-        super(TestDecisionTreeRegressionJPMMLParity, self).init_data()
-        super(TestDecisionTreeRegressionJPMMLParity, self).setUp()
+        self.init_data()
         self.converter = DecisionTreeConverter(
             estimator=self.model,
             context=self.ctx,

--- a/sklearn_pmml/convert/test/test_decisionTreeClassifierConverter.py
+++ b/sklearn_pmml/convert/test/test_decisionTreeClassifierConverter.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
 import numpy as np
+from jpmml_test import JPMMLClassificationTest, JPMMLRegressionTest
 
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 
@@ -8,6 +9,8 @@ from sklearn_pmml.convert import TransformationContext, pmml_row
 from sklearn_pmml.convert.features import *
 from sklearn_pmml.convert.tree import DecisionTreeConverter
 from sklearn_pmml import pmml
+
+from unittest import TestCase
 
 
 class TestDecisionTreeClassifierConverter(TestCase):
@@ -114,3 +117,28 @@ class TestDecisionTreeRegressorConverter(TestCase):
         assert tm.Node is not None, 'Missing root node'
         assert tm.Node.recordCount == 4
         assert tm.Node.True_ is not None, 'Root condition should always be True'
+
+
+class TestDecisionTreeClassificationJPMMLParity(TestCase, JPMMLClassificationTest):
+
+    def setUp(self):
+        self.model = DecisionTreeClassifier()
+        super(TestDecisionTreeClassificationJPMMLParity, self).init_data()
+        super(TestDecisionTreeClassificationJPMMLParity, self).setUp()
+        self.converter = DecisionTreeConverter(
+            estimator=self.model,
+            context=self.ctx,
+            mode=DecisionTreeConverter.MODE_CLASSIFICATION
+        )
+
+class TestDecisionTreeRegressionJPMMLParity(TestCase, JPMMLRegressionTest):
+
+    def setUp(self):
+        self.model = DecisionTreeRegressor()
+        super(TestDecisionTreeRegressionJPMMLParity, self).init_data()
+        super(TestDecisionTreeRegressionJPMMLParity, self).setUp()
+        self.converter = DecisionTreeConverter(
+            estimator=self.model,
+            context=self.ctx,
+            mode=DecisionTreeConverter.MODE_REGRESSION
+        )

--- a/sklearn_pmml/convert/test/test_randomForestConverter.py
+++ b/sklearn_pmml/convert/test/test_randomForestConverter.py
@@ -1,0 +1,25 @@
+__author__ = 'evancox'
+
+from jpmml_test import JPMMLClassificationTest, JPMMLTest
+from unittest import TestCase
+
+from sklearn.ensemble import RandomForestClassifier
+
+
+from sklearn_pmml.convert.random_forest import RandomForestClassifierConverter
+
+class TestRandomForestClassifierParity(TestCase, JPMMLClassificationTest):
+
+    @classmethod
+    def setUpClass(cls):
+        JPMMLTest.init_jpmml()
+
+
+    def setUp(self):
+        self.model = RandomForestClassifier()
+        super(TestRandomForestClassifierParity, self).init_data()
+        super(TestRandomForestClassifierParity, self).setUp()
+        self.converter = RandomForestClassifierConverter(
+            estimator=self.model,
+            context=self.ctx
+        )

--- a/sklearn_pmml/convert/test/test_randomForestConverter.py
+++ b/sklearn_pmml/convert/test/test_randomForestConverter.py
@@ -12,14 +12,16 @@ class TestRandomForestClassifierParity(TestCase, JPMMLClassificationTest):
 
     @classmethod
     def setUpClass(cls):
-        JPMMLTest.init_jpmml()
+        if JPMMLTest.can_run():
+            JPMMLTest.init_jpmml()
 
 
     def setUp(self):
         self.model = RandomForestClassifier()
-        super(TestRandomForestClassifierParity, self).init_data()
-        super(TestRandomForestClassifierParity, self).setUp()
+        self.init_data()
         self.converter = RandomForestClassifierConverter(
             estimator=self.model,
             context=self.ctx
         )
+
+

--- a/sklearn_pmml/convert/tree.py
+++ b/sklearn_pmml/convert/tree.py
@@ -44,6 +44,7 @@ class DecisionTreeConverter(EstimatorConverter):
             'Either build transformation dictionary or provide {} schema in context'.format(self.SCHEMA_NUMERIC)
         tm = pmml.TreeModel(functionName=self.model_function_name, splitCharacteristic=self.SPLIT_BINARY)
         tm.append(self.mining_schema())
+        tm.append(self.output())
         tm.Node = self._transform_node(
             self.estimator.tree_,
             self.NODE_ROOT,


### PR DESCRIPTION
Hey, made a couple of changes.

First is that I included a small Java project and added some JPMML integration tests.  The JPMML jar linked in the POM is from an earlier version of JPMML that is BSD licensed so that the AGPL won't affect people that want to update this on their own.  I added integration tests for Decision Tree Classifier/Regressor and the RandomForestClassifier.  It should be straightforward to add for the GradientBoostingClassifier.  Right now all the integration test does is generate 10 numerical features and compares the output from the sklearn model to the jpmml evaluator.  I will extend it later to support categorical features.  The tests will log a warning and pass if someone doesn't have java and or maven installed.
