### PR TITLE
Fixing GBRT, changing output format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda/bin:$PATH
   - conda update --yes conda
-  - travis_retry conda install --yes python=$TRAVIS_PYTHON_VERSION pip numpy scipy
+  - travis_retry conda install --yes python=$TRAVIS_PYTHON_VERSION pip numpy scipy scikit-learn
 
 install:
   - travis_retry pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda/bin:$PATH
   - conda update --yes conda
-  - travis_retry conda install --yes python=$TRAVIS_PYTHON_VERSION pip numpy scipy scikit-learn
+  - travis_retry conda install --yes python=$TRAVIS_PYTHON_VERSION pip numpy scipy scikit-learn pandas
 
 install:
   - travis_retry pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 #  - "nightly"
 # command to install dependencies
 before_install:
-  - sudo add-apt-repository ppa:webupd8team/java
+  - sudo add-apt-repository ppa:webupd8team/java -y
   - sudo apt-get update -qq
   - sudo apt-get install oracle-java8-installer
   - sudo apt-get install maven

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ before_install:
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda/bin:$PATH
   - conda update --yes conda
-  - travis_retry conda install --yes python=$TRAVIS_PYTHON_VERSION pip numpy scipy scikit-learn pandas
+  # install the heaviest dependencies with conda to save some time
+  - travis_retry conda install --yes python=$TRAVIS_PYTHON_VERSION pip numpy scipy scikit-learn pandas lxml
 
 install:
   - travis_retry pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -9,5 +9,16 @@ A library that allows serialization of SciKit-Learn estimators into PMML
 - GradientBoostingClassifier
 - RandomForestClassifier
 
-# Usage
-TBD
+# PMML output
+
+## Classification
+Classifier converters can only operate with categorical outputs, and for each categorical output variable ```varname``` 
+the PMML output contains the following outputs:
+
+| Output | Type | Description |
+-------------------------------
+| varname | categorical | label for the instance |
+| varname::label | double | probability for a given label |
+
+## Regression
+Regression model PMML outputs the numeric response variable named as the output variable

--- a/README.md
+++ b/README.md
@@ -8,3 +8,6 @@ A library that allows serialization of SciKit-Learn estimators into PMML
 - DecisionTreeRegressor
 - GradientBoostingClassifier
 - RandomForestClassifier
+
+# Usage
+TBD

--- a/examples/pmml/DecisionTreeClassifier.pmml
+++ b/examples/pmml/DecisionTreeClassifier.pmml
@@ -1,0 +1,78 @@
+<?xml version="1.0" ?>
+<ns1:PMML xmlns:ns1="http://www.dmg.org/PMML-4_2" version="4.2">
+    <ns1:Header/>
+    <ns1:DataDictionary>
+        <ns1:DataField dataType="integer" name="internal::y" optype="categorical">
+            <ns1:Value value="0"/>
+            <ns1:Value value="1"/>
+            <ns1:Value value="2"/>
+        </ns1:DataField>
+        <ns1:DataField dataType="integer" name="y" optype="categorical">
+            <ns1:Value value="0"/>
+            <ns1:Value value="1"/>
+            <ns1:Value value="2"/>
+        </ns1:DataField>
+        <ns1:DataField dataType="double" name="col_0" optype="continuous"/>
+        <ns1:DataField dataType="double" name="col_1" optype="continuous"/>
+        <ns1:DataField dataType="double" name="col_2" optype="continuous"/>
+        <ns1:DataField dataType="double" name="col_3" optype="continuous"/>
+    </ns1:DataDictionary>
+    <ns1:TransformationDictionary/>
+    <ns1:TreeModel functionName="classification" splitCharacteristic="binarySplit">
+        <ns1:MiningSchema>
+            <ns1:MiningField invalidValueTreatment="asIs" name="col_0"/>
+            <ns1:MiningField invalidValueTreatment="asIs" name="col_1"/>
+            <ns1:MiningField invalidValueTreatment="asIs" name="col_2"/>
+            <ns1:MiningField invalidValueTreatment="asIs" name="col_3"/>
+            <ns1:MiningField name="internal::y" usageType="predicted"/>
+        </ns1:MiningSchema>
+        <ns1:Output>
+            <ns1:OutputField dataType="integer" feature="predictedValue" name="y" optype="categorical"/>
+            <ns1:OutputField dataType="double" feature="probability" name="y::0" optype="continuous" targetField="internal::y" value="0"/>
+            <ns1:OutputField dataType="double" feature="probability" name="y::1" optype="continuous" targetField="internal::y" value="1"/>
+            <ns1:OutputField dataType="double" feature="probability" name="y::2" optype="continuous" targetField="internal::y" value="2"/>
+        </ns1:Output>
+        <ns1:Node recordCount="500.0" score="1">
+            <ns1:True/>
+            <ns1:ScoreDistribution confidence="0.328" recordCount="164.0" value="0"/>
+            <ns1:ScoreDistribution confidence="0.346" recordCount="173.0" value="1"/>
+            <ns1:ScoreDistribution confidence="0.326" recordCount="163.0" value="2"/>
+            <ns1:Node recordCount="52.0" score="1">
+                <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="-1.23250246048"/>
+                <ns1:ScoreDistribution confidence="0.115384615385" recordCount="6.0" value="0"/>
+                <ns1:ScoreDistribution confidence="0.596153846154" recordCount="31.0" value="1"/>
+                <ns1:ScoreDistribution confidence="0.288461538462" recordCount="15.0" value="2"/>
+                <ns1:Node recordCount="49.0" score="1">
+                    <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="1.78307962418"/>
+                    <ns1:ScoreDistribution confidence="0.122448979592" recordCount="6.0" value="0"/>
+                    <ns1:ScoreDistribution confidence="0.632653061224" recordCount="31.0" value="1"/>
+                    <ns1:ScoreDistribution confidence="0.244897959184" recordCount="12.0" value="2"/>
+                </ns1:Node>
+                <ns1:Node recordCount="3.0" score="2">
+                    <ns1:True/>
+                    <ns1:ScoreDistribution confidence="0.0" recordCount="0.0" value="0"/>
+                    <ns1:ScoreDistribution confidence="0.0" recordCount="0.0" value="1"/>
+                    <ns1:ScoreDistribution confidence="1.0" recordCount="3.0" value="2"/>
+                </ns1:Node>
+            </ns1:Node>
+            <ns1:Node recordCount="448.0" score="0">
+                <ns1:True/>
+                <ns1:ScoreDistribution confidence="0.352678571429" recordCount="158.0" value="0"/>
+                <ns1:ScoreDistribution confidence="0.316964285714" recordCount="142.0" value="1"/>
+                <ns1:ScoreDistribution confidence="0.330357142857" recordCount="148.0" value="2"/>
+                <ns1:Node recordCount="227.0" score="2">
+                    <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="0.21028482914"/>
+                    <ns1:ScoreDistribution confidence="0.339207048458" recordCount="77.0" value="0"/>
+                    <ns1:ScoreDistribution confidence="0.251101321586" recordCount="57.0" value="1"/>
+                    <ns1:ScoreDistribution confidence="0.409691629956" recordCount="93.0" value="2"/>
+                </ns1:Node>
+                <ns1:Node recordCount="221.0" score="1">
+                    <ns1:True/>
+                    <ns1:ScoreDistribution confidence="0.366515837104" recordCount="81.0" value="0"/>
+                    <ns1:ScoreDistribution confidence="0.384615384615" recordCount="85.0" value="1"/>
+                    <ns1:ScoreDistribution confidence="0.248868778281" recordCount="55.0" value="2"/>
+                </ns1:Node>
+            </ns1:Node>
+        </ns1:Node>
+    </ns1:TreeModel>
+</ns1:PMML>

--- a/examples/pmml/DecisionTreeRegression.pmml
+++ b/examples/pmml/DecisionTreeRegression.pmml
@@ -1,0 +1,1256 @@
+<?xml version="1.0" ?>
+<ns1:PMML xmlns:ns1="http://www.dmg.org/PMML-4_2" version="4.2">
+    <ns1:Header/>
+    <ns1:DataDictionary>
+        <ns1:DataField dataType="integer" name="y" optype="continuous"/>
+        <ns1:DataField dataType="double" name="col_0" optype="continuous"/>
+        <ns1:DataField dataType="double" name="col_1" optype="continuous"/>
+        <ns1:DataField dataType="double" name="col_2" optype="continuous"/>
+        <ns1:DataField dataType="double" name="col_3" optype="continuous"/>
+    </ns1:DataDictionary>
+    <ns1:TransformationDictionary/>
+    <ns1:TreeModel functionName="regression" splitCharacteristic="binarySplit">
+        <ns1:MiningSchema>
+            <ns1:MiningField invalidValueTreatment="asIs" name="col_0"/>
+            <ns1:MiningField invalidValueTreatment="asIs" name="col_1"/>
+            <ns1:MiningField invalidValueTreatment="asIs" name="col_2"/>
+            <ns1:MiningField invalidValueTreatment="asIs" name="col_3"/>
+        </ns1:MiningSchema>
+        <ns1:Output>
+            <ns1:OutputField dataType="integer" feature="predictedValue" name="y" optype="continuous"/>
+        </ns1:Output>
+        <ns1:Node recordCount="500.0">
+            <ns1:True/>
+            <ns1:Node recordCount="202.0">
+                <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="-0.261430621147"/>
+                <ns1:Node recordCount="195.0">
+                    <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="1.84803807735"/>
+                    <ns1:Node recordCount="62.0">
+                        <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="-0.515709280968"/>
+                        <ns1:Node recordCount="56.0">
+                            <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="-0.3104159832"/>
+                            <ns1:Node recordCount="37.0">
+                                <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="-0.965559124947"/>
+                                <ns1:Node recordCount="33.0">
+                                    <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="-1.02813243866"/>
+                                    <ns1:Node recordCount="30.0">
+                                        <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="-0.412048459053"/>
+                                        <ns1:Node recordCount="21.0">
+                                            <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="-0.68850004673"/>
+                                            <ns1:Node recordCount="19.0">
+                                                <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="-1.11429023743"/>
+                                                <ns1:Node recordCount="17.0">
+                                                    <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="-0.756451129913"/>
+                                                    <ns1:Node recordCount="10.0">
+                                                        <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="0.410063415766"/>
+                                                        <ns1:Node recordCount="8.0">
+                                                            <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="-1.25220155716"/>
+                                                            <ns1:Node recordCount="7.0" score="1.0">
+                                                                <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="0.349797666073"/>
+                                                            </ns1:Node>
+                                                            <ns1:Node recordCount="1.0" score="2.0">
+                                                                <ns1:True/>
+                                                            </ns1:Node>
+                                                        </ns1:Node>
+                                                        <ns1:Node recordCount="2.0" score="2.0">
+                                                            <ns1:True/>
+                                                        </ns1:Node>
+                                                    </ns1:Node>
+                                                    <ns1:Node recordCount="7.0">
+                                                        <ns1:True/>
+                                                        <ns1:Node recordCount="4.0">
+                                                            <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="-1.09635782242"/>
+                                                            <ns1:Node recordCount="1.0" score="2.0">
+                                                                <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="-2.13068842888"/>
+                                                            </ns1:Node>
+                                                            <ns1:Node recordCount="3.0" score="1.0">
+                                                                <ns1:True/>
+                                                            </ns1:Node>
+                                                        </ns1:Node>
+                                                        <ns1:Node recordCount="3.0" score="0.0">
+                                                            <ns1:True/>
+                                                        </ns1:Node>
+                                                    </ns1:Node>
+                                                </ns1:Node>
+                                                <ns1:Node recordCount="2.0" score="0.0">
+                                                    <ns1:True/>
+                                                </ns1:Node>
+                                            </ns1:Node>
+                                            <ns1:Node recordCount="2.0" score="0.0">
+                                                <ns1:True/>
+                                            </ns1:Node>
+                                        </ns1:Node>
+                                        <ns1:Node recordCount="9.0">
+                                            <ns1:True/>
+                                            <ns1:Node recordCount="1.0" score="0.0">
+                                                <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="-2.79309177399"/>
+                                            </ns1:Node>
+                                            <ns1:Node recordCount="8.0">
+                                                <ns1:True/>
+                                                <ns1:Node recordCount="5.0">
+                                                    <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="0.307529121637"/>
+                                                    <ns1:Node recordCount="1.0" score="2.0">
+                                                        <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="-0.685786485672"/>
+                                                    </ns1:Node>
+                                                    <ns1:Node recordCount="4.0" score="1.0">
+                                                        <ns1:True/>
+                                                    </ns1:Node>
+                                                </ns1:Node>
+                                                <ns1:Node recordCount="3.0" score="2.0">
+                                                    <ns1:True/>
+                                                </ns1:Node>
+                                            </ns1:Node>
+                                        </ns1:Node>
+                                    </ns1:Node>
+                                    <ns1:Node recordCount="3.0" score="0.0">
+                                        <ns1:True/>
+                                    </ns1:Node>
+                                </ns1:Node>
+                                <ns1:Node recordCount="4.0" score="2.0">
+                                    <ns1:True/>
+                                </ns1:Node>
+                            </ns1:Node>
+                            <ns1:Node recordCount="19.0">
+                                <ns1:True/>
+                                <ns1:Node recordCount="16.0">
+                                    <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="-0.399435073137"/>
+                                    <ns1:Node recordCount="2.0" score="1.0">
+                                        <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="-1.81295895576"/>
+                                    </ns1:Node>
+                                    <ns1:Node recordCount="14.0">
+                                        <ns1:True/>
+                                        <ns1:Node recordCount="8.0">
+                                            <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="-0.0932206362486"/>
+                                            <ns1:Node recordCount="6.0">
+                                                <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="-0.576177597046"/>
+                                                <ns1:Node recordCount="3.0">
+                                                    <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="-0.945207476616"/>
+                                                    <ns1:Node recordCount="2.0" score="0.0">
+                                                        <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="-0.0225269198418"/>
+                                                    </ns1:Node>
+                                                    <ns1:Node recordCount="1.0" score="1.0">
+                                                        <ns1:True/>
+                                                    </ns1:Node>
+                                                </ns1:Node>
+                                                <ns1:Node recordCount="3.0" score="1.0">
+                                                    <ns1:True/>
+                                                </ns1:Node>
+                                            </ns1:Node>
+                                            <ns1:Node recordCount="2.0" score="0.0">
+                                                <ns1:True/>
+                                            </ns1:Node>
+                                        </ns1:Node>
+                                        <ns1:Node recordCount="6.0" score="0.0">
+                                            <ns1:True/>
+                                        </ns1:Node>
+                                    </ns1:Node>
+                                </ns1:Node>
+                                <ns1:Node recordCount="3.0">
+                                    <ns1:True/>
+                                    <ns1:Node recordCount="2.0" score="2.0">
+                                        <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="1.37965726852"/>
+                                    </ns1:Node>
+                                    <ns1:Node recordCount="1.0" score="0.0">
+                                        <ns1:True/>
+                                    </ns1:Node>
+                                </ns1:Node>
+                            </ns1:Node>
+                        </ns1:Node>
+                        <ns1:Node recordCount="6.0">
+                            <ns1:True/>
+                            <ns1:Node recordCount="5.0">
+                                <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="-0.275016844273"/>
+                                <ns1:Node recordCount="4.0" score="2.0">
+                                    <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="0.209128022194"/>
+                                </ns1:Node>
+                                <ns1:Node recordCount="1.0" score="1.0">
+                                    <ns1:True/>
+                                </ns1:Node>
+                            </ns1:Node>
+                            <ns1:Node recordCount="1.0" score="1.0">
+                                <ns1:True/>
+                            </ns1:Node>
+                        </ns1:Node>
+                    </ns1:Node>
+                    <ns1:Node recordCount="133.0">
+                        <ns1:True/>
+                        <ns1:Node recordCount="90.0">
+                            <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="0.817398905754"/>
+                            <ns1:Node recordCount="23.0">
+                                <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="-0.471895813942"/>
+                                <ns1:Node recordCount="3.0" score="2.0">
+                                    <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="-2.03589391708"/>
+                                </ns1:Node>
+                                <ns1:Node recordCount="20.0">
+                                    <ns1:True/>
+                                    <ns1:Node recordCount="3.0">
+                                        <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="-0.426958441734"/>
+                                        <ns1:Node recordCount="2.0" score="2.0">
+                                            <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="0.33171287179"/>
+                                        </ns1:Node>
+                                        <ns1:Node recordCount="1.0" score="1.0">
+                                            <ns1:True/>
+                                        </ns1:Node>
+                                    </ns1:Node>
+                                    <ns1:Node recordCount="17.0">
+                                        <ns1:True/>
+                                        <ns1:Node recordCount="4.0" score="0.0">
+                                            <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="0.0806639194489"/>
+                                        </ns1:Node>
+                                        <ns1:Node recordCount="13.0">
+                                            <ns1:True/>
+                                            <ns1:Node recordCount="8.0">
+                                                <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="0.107442036271"/>
+                                                <ns1:Node recordCount="1.0" score="0.0">
+                                                    <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="-0.421319752932"/>
+                                                </ns1:Node>
+                                                <ns1:Node recordCount="7.0">
+                                                    <ns1:True/>
+                                                    <ns1:Node recordCount="3.0" score="2.0">
+                                                        <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="0.564626932144"/>
+                                                    </ns1:Node>
+                                                    <ns1:Node recordCount="4.0">
+                                                        <ns1:True/>
+                                                        <ns1:Node recordCount="1.0" score="2.0">
+                                                            <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="-1.20216119289"/>
+                                                        </ns1:Node>
+                                                        <ns1:Node recordCount="3.0" score="1.0">
+                                                            <ns1:True/>
+                                                        </ns1:Node>
+                                                    </ns1:Node>
+                                                </ns1:Node>
+                                            </ns1:Node>
+                                            <ns1:Node recordCount="5.0">
+                                                <ns1:True/>
+                                                <ns1:Node recordCount="3.0" score="0.0">
+                                                    <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="0.568754851818"/>
+                                                </ns1:Node>
+                                                <ns1:Node recordCount="2.0" score="1.0">
+                                                    <ns1:True/>
+                                                </ns1:Node>
+                                            </ns1:Node>
+                                        </ns1:Node>
+                                    </ns1:Node>
+                                </ns1:Node>
+                            </ns1:Node>
+                            <ns1:Node recordCount="67.0">
+                                <ns1:True/>
+                                <ns1:Node recordCount="30.0">
+                                    <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="0.172692418098"/>
+                                    <ns1:Node recordCount="2.0" score="1.0">
+                                        <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="-2.1314060688"/>
+                                    </ns1:Node>
+                                    <ns1:Node recordCount="28.0">
+                                        <ns1:True/>
+                                        <ns1:Node recordCount="9.0">
+                                            <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="-0.517086744308"/>
+                                            <ns1:Node recordCount="7.0">
+                                                <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="0.409582287073"/>
+                                                <ns1:Node recordCount="4.0" score="2.0">
+                                                    <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="-0.76461815834"/>
+                                                </ns1:Node>
+                                                <ns1:Node recordCount="3.0">
+                                                    <ns1:True/>
+                                                    <ns1:Node recordCount="1.0" score="2.0">
+                                                        <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="-0.887925624847"/>
+                                                    </ns1:Node>
+                                                    <ns1:Node recordCount="2.0" score="1.0">
+                                                        <ns1:True/>
+                                                    </ns1:Node>
+                                                </ns1:Node>
+                                            </ns1:Node>
+                                            <ns1:Node recordCount="2.0" score="1.0">
+                                                <ns1:True/>
+                                            </ns1:Node>
+                                        </ns1:Node>
+                                        <ns1:Node recordCount="19.0">
+                                            <ns1:True/>
+                                            <ns1:Node recordCount="13.0" score="2.0">
+                                                <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="0.0285335686058"/>
+                                            </ns1:Node>
+                                            <ns1:Node recordCount="6.0">
+                                                <ns1:True/>
+                                                <ns1:Node recordCount="1.0" score="1.0">
+                                                    <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="0.0452669784427"/>
+                                                </ns1:Node>
+                                                <ns1:Node recordCount="5.0" score="2.0">
+                                                    <ns1:True/>
+                                                </ns1:Node>
+                                            </ns1:Node>
+                                        </ns1:Node>
+                                    </ns1:Node>
+                                </ns1:Node>
+                                <ns1:Node recordCount="37.0">
+                                    <ns1:True/>
+                                    <ns1:Node recordCount="20.0">
+                                        <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="0.167518630624"/>
+                                        <ns1:Node recordCount="5.0">
+                                            <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="-1.31829309464"/>
+                                            <ns1:Node recordCount="4.0" score="1.0">
+                                                <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="0.374352365732"/>
+                                            </ns1:Node>
+                                            <ns1:Node recordCount="1.0" score="0.0">
+                                                <ns1:True/>
+                                            </ns1:Node>
+                                        </ns1:Node>
+                                        <ns1:Node recordCount="15.0">
+                                            <ns1:True/>
+                                            <ns1:Node recordCount="14.0">
+                                                <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="1.91325950623"/>
+                                                <ns1:Node recordCount="11.0" score="2.0">
+                                                    <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="1.4715461731"/>
+                                                </ns1:Node>
+                                                <ns1:Node recordCount="3.0">
+                                                    <ns1:True/>
+                                                    <ns1:Node recordCount="1.0" score="1.0">
+                                                        <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="1.56623208523"/>
+                                                    </ns1:Node>
+                                                    <ns1:Node recordCount="2.0" score="2.0">
+                                                        <ns1:True/>
+                                                    </ns1:Node>
+                                                </ns1:Node>
+                                            </ns1:Node>
+                                            <ns1:Node recordCount="1.0" score="1.0">
+                                                <ns1:True/>
+                                            </ns1:Node>
+                                        </ns1:Node>
+                                    </ns1:Node>
+                                    <ns1:Node recordCount="17.0">
+                                        <ns1:True/>
+                                        <ns1:Node recordCount="12.0">
+                                            <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="0.712297618389"/>
+                                            <ns1:Node recordCount="6.0" score="1.0">
+                                                <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="-1.09562945366"/>
+                                            </ns1:Node>
+                                            <ns1:Node recordCount="6.0">
+                                                <ns1:True/>
+                                                <ns1:Node recordCount="3.0" score="0.0">
+                                                    <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="0.4885391891"/>
+                                                </ns1:Node>
+                                                <ns1:Node recordCount="3.0" score="1.0">
+                                                    <ns1:True/>
+                                                </ns1:Node>
+                                            </ns1:Node>
+                                        </ns1:Node>
+                                        <ns1:Node recordCount="5.0">
+                                            <ns1:True/>
+                                            <ns1:Node recordCount="1.0" score="1.0">
+                                                <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="-0.766536951065"/>
+                                            </ns1:Node>
+                                            <ns1:Node recordCount="4.0" score="2.0">
+                                                <ns1:True/>
+                                            </ns1:Node>
+                                        </ns1:Node>
+                                    </ns1:Node>
+                                </ns1:Node>
+                            </ns1:Node>
+                        </ns1:Node>
+                        <ns1:Node recordCount="43.0">
+                            <ns1:True/>
+                            <ns1:Node recordCount="38.0">
+                                <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="1.08719360828"/>
+                                <ns1:Node recordCount="7.0">
+                                    <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="0.949406147003"/>
+                                    <ns1:Node recordCount="2.0" score="1.0">
+                                        <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="-0.603809654713"/>
+                                    </ns1:Node>
+                                    <ns1:Node recordCount="5.0" score="0.0">
+                                        <ns1:True/>
+                                    </ns1:Node>
+                                </ns1:Node>
+                                <ns1:Node recordCount="31.0">
+                                    <ns1:True/>
+                                    <ns1:Node recordCount="10.0">
+                                        <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="-1.00488388538"/>
+                                        <ns1:Node recordCount="6.0" score="1.0">
+                                            <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="1.77494633198"/>
+                                        </ns1:Node>
+                                        <ns1:Node recordCount="4.0">
+                                            <ns1:True/>
+                                            <ns1:Node recordCount="3.0" score="2.0">
+                                                <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="2.33305311203"/>
+                                            </ns1:Node>
+                                            <ns1:Node recordCount="1.0" score="1.0">
+                                                <ns1:True/>
+                                            </ns1:Node>
+                                        </ns1:Node>
+                                    </ns1:Node>
+                                    <ns1:Node recordCount="21.0">
+                                        <ns1:True/>
+                                        <ns1:Node recordCount="10.0">
+                                            <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="1.5360481739"/>
+                                            <ns1:Node recordCount="5.0">
+                                                <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="-0.479238212109"/>
+                                                <ns1:Node recordCount="1.0" score="2.0">
+                                                    <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="-0.946069121361"/>
+                                                </ns1:Node>
+                                                <ns1:Node recordCount="4.0">
+                                                    <ns1:True/>
+                                                    <ns1:Node recordCount="2.0">
+                                                        <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="-0.68064892292"/>
+                                                        <ns1:Node recordCount="1.0" score="0.0">
+                                                            <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="-0.857309579849"/>
+                                                        </ns1:Node>
+                                                        <ns1:Node recordCount="1.0" score="1.0">
+                                                            <ns1:True/>
+                                                        </ns1:Node>
+                                                    </ns1:Node>
+                                                    <ns1:Node recordCount="2.0" score="0.0">
+                                                        <ns1:True/>
+                                                    </ns1:Node>
+                                                </ns1:Node>
+                                            </ns1:Node>
+                                            <ns1:Node recordCount="5.0">
+                                                <ns1:True/>
+                                                <ns1:Node recordCount="4.0" score="2.0">
+                                                    <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="-0.319344222546"/>
+                                                </ns1:Node>
+                                                <ns1:Node recordCount="1.0" score="1.0">
+                                                    <ns1:True/>
+                                                </ns1:Node>
+                                            </ns1:Node>
+                                        </ns1:Node>
+                                        <ns1:Node recordCount="11.0">
+                                            <ns1:True/>
+                                            <ns1:Node recordCount="2.0">
+                                                <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="-0.499220848083"/>
+                                                <ns1:Node recordCount="1.0" score="2.0">
+                                                    <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="-0.681802749634"/>
+                                                </ns1:Node>
+                                                <ns1:Node recordCount="1.0" score="0.0">
+                                                    <ns1:True/>
+                                                </ns1:Node>
+                                            </ns1:Node>
+                                            <ns1:Node recordCount="9.0">
+                                                <ns1:True/>
+                                                <ns1:Node recordCount="8.0">
+                                                    <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="2.45201301575"/>
+                                                    <ns1:Node recordCount="3.0">
+                                                        <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="-0.730724275112"/>
+                                                        <ns1:Node recordCount="2.0" score="0.0">
+                                                            <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="1.79942667484"/>
+                                                        </ns1:Node>
+                                                        <ns1:Node recordCount="1.0" score="1.0">
+                                                            <ns1:True/>
+                                                        </ns1:Node>
+                                                    </ns1:Node>
+                                                    <ns1:Node recordCount="5.0" score="0.0">
+                                                        <ns1:True/>
+                                                    </ns1:Node>
+                                                </ns1:Node>
+                                                <ns1:Node recordCount="1.0" score="1.0">
+                                                    <ns1:True/>
+                                                </ns1:Node>
+                                            </ns1:Node>
+                                        </ns1:Node>
+                                    </ns1:Node>
+                                </ns1:Node>
+                            </ns1:Node>
+                            <ns1:Node recordCount="5.0">
+                                <ns1:True/>
+                                <ns1:Node recordCount="1.0" score="1.0">
+                                    <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="-0.684428453445"/>
+                                </ns1:Node>
+                                <ns1:Node recordCount="4.0" score="2.0">
+                                    <ns1:True/>
+                                </ns1:Node>
+                            </ns1:Node>
+                        </ns1:Node>
+                    </ns1:Node>
+                </ns1:Node>
+                <ns1:Node recordCount="7.0">
+                    <ns1:True/>
+                    <ns1:Node recordCount="3.0">
+                        <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="-0.914817333221"/>
+                        <ns1:Node recordCount="2.0" score="1.0">
+                            <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="2.29343032837"/>
+                        </ns1:Node>
+                        <ns1:Node recordCount="1.0" score="0.0">
+                            <ns1:True/>
+                        </ns1:Node>
+                    </ns1:Node>
+                    <ns1:Node recordCount="4.0" score="0.0">
+                        <ns1:True/>
+                    </ns1:Node>
+                </ns1:Node>
+            </ns1:Node>
+            <ns1:Node recordCount="298.0">
+                <ns1:True/>
+                <ns1:Node recordCount="266.0">
+                    <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="1.2553768158"/>
+                    <ns1:Node recordCount="155.0">
+                        <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="0.308671563864"/>
+                        <ns1:Node recordCount="18.0">
+                            <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="-1.47402572632"/>
+                            <ns1:Node recordCount="15.0">
+                                <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="1.51404690742"/>
+                                <ns1:Node recordCount="6.0" score="2.0">
+                                    <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="-0.342633217573"/>
+                                </ns1:Node>
+                                <ns1:Node recordCount="9.0">
+                                    <ns1:True/>
+                                    <ns1:Node recordCount="2.0" score="2.0">
+                                        <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="0.18967834115"/>
+                                    </ns1:Node>
+                                    <ns1:Node recordCount="7.0">
+                                        <ns1:True/>
+                                        <ns1:Node recordCount="6.0">
+                                            <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="1.09322273731"/>
+                                            <ns1:Node recordCount="4.0" score="1.0">
+                                                <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="0.581643521786"/>
+                                            </ns1:Node>
+                                            <ns1:Node recordCount="2.0" score="0.0">
+                                                <ns1:True/>
+                                            </ns1:Node>
+                                        </ns1:Node>
+                                        <ns1:Node recordCount="1.0" score="2.0">
+                                            <ns1:True/>
+                                        </ns1:Node>
+                                    </ns1:Node>
+                                </ns1:Node>
+                            </ns1:Node>
+                            <ns1:Node recordCount="3.0">
+                                <ns1:True/>
+                                <ns1:Node recordCount="2.0" score="0.0">
+                                    <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="1.93114495277"/>
+                                </ns1:Node>
+                                <ns1:Node recordCount="1.0" score="1.0">
+                                    <ns1:True/>
+                                </ns1:Node>
+                            </ns1:Node>
+                        </ns1:Node>
+                        <ns1:Node recordCount="137.0">
+                            <ns1:True/>
+                            <ns1:Node recordCount="67.0">
+                                <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="-0.40389084816"/>
+                                <ns1:Node recordCount="65.0">
+                                    <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="-0.432241290808"/>
+                                    <ns1:Node recordCount="3.0">
+                                        <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="-1.05278038979"/>
+                                        <ns1:Node recordCount="1.0" score="1.0">
+                                            <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="-1.55923819542"/>
+                                        </ns1:Node>
+                                        <ns1:Node recordCount="2.0" score="2.0">
+                                            <ns1:True/>
+                                        </ns1:Node>
+                                    </ns1:Node>
+                                    <ns1:Node recordCount="62.0">
+                                        <ns1:True/>
+                                        <ns1:Node recordCount="16.0">
+                                            <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="-0.495171278715"/>
+                                            <ns1:Node recordCount="7.0">
+                                                <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="0.633709430695"/>
+                                                <ns1:Node recordCount="1.0" score="1.0">
+                                                    <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="-1.39047694206"/>
+                                                </ns1:Node>
+                                                <ns1:Node recordCount="6.0" score="0.0">
+                                                    <ns1:True/>
+                                                </ns1:Node>
+                                            </ns1:Node>
+                                            <ns1:Node recordCount="9.0">
+                                                <ns1:True/>
+                                                <ns1:Node recordCount="6.0">
+                                                    <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="-0.625428915024"/>
+                                                    <ns1:Node recordCount="5.0" score="1.0">
+                                                        <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="-0.57585299015"/>
+                                                    </ns1:Node>
+                                                    <ns1:Node recordCount="1.0" score="2.0">
+                                                        <ns1:True/>
+                                                    </ns1:Node>
+                                                </ns1:Node>
+                                                <ns1:Node recordCount="3.0">
+                                                    <ns1:True/>
+                                                    <ns1:Node recordCount="2.0" score="0.0">
+                                                        <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="0.307069987059"/>
+                                                    </ns1:Node>
+                                                    <ns1:Node recordCount="1.0" score="1.0">
+                                                        <ns1:True/>
+                                                    </ns1:Node>
+                                                </ns1:Node>
+                                            </ns1:Node>
+                                        </ns1:Node>
+                                        <ns1:Node recordCount="46.0">
+                                            <ns1:True/>
+                                            <ns1:Node recordCount="4.0" score="2.0">
+                                                <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="-0.372727811337"/>
+                                            </ns1:Node>
+                                            <ns1:Node recordCount="42.0">
+                                                <ns1:True/>
+                                                <ns1:Node recordCount="27.0">
+                                                    <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="0.345563739538"/>
+                                                    <ns1:Node recordCount="15.0">
+                                                        <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="-0.979352772236"/>
+                                                        <ns1:Node recordCount="10.0">
+                                                            <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="-1.19858193398"/>
+                                                            <ns1:Node recordCount="3.0" score="1.0">
+                                                                <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="-1.54157066345"/>
+                                                            </ns1:Node>
+                                                            <ns1:Node recordCount="7.0">
+                                                                <ns1:True/>
+                                                                <ns1:Node recordCount="2.0" score="1.0">
+                                                                    <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="-2.45414590836"/>
+                                                                </ns1:Node>
+                                                                <ns1:Node recordCount="5.0" score="0.0">
+                                                                    <ns1:True/>
+                                                                </ns1:Node>
+                                                            </ns1:Node>
+                                                        </ns1:Node>
+                                                        <ns1:Node recordCount="5.0">
+                                                            <ns1:True/>
+                                                            <ns1:Node recordCount="3.0">
+                                                                <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="-0.347871154547"/>
+                                                                <ns1:Node recordCount="2.0" score="1.0">
+                                                                    <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="0.639891862869"/>
+                                                                </ns1:Node>
+                                                                <ns1:Node recordCount="1.0" score="2.0">
+                                                                    <ns1:True/>
+                                                                </ns1:Node>
+                                                            </ns1:Node>
+                                                            <ns1:Node recordCount="2.0" score="2.0">
+                                                                <ns1:True/>
+                                                            </ns1:Node>
+                                                        </ns1:Node>
+                                                    </ns1:Node>
+                                                    <ns1:Node recordCount="12.0">
+                                                        <ns1:True/>
+                                                        <ns1:Node recordCount="7.0">
+                                                            <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="0.615099966526"/>
+                                                            <ns1:Node recordCount="6.0" score="0.0">
+                                                                <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="1.66405105591"/>
+                                                            </ns1:Node>
+                                                            <ns1:Node recordCount="1.0" score="1.0">
+                                                                <ns1:True/>
+                                                            </ns1:Node>
+                                                        </ns1:Node>
+                                                        <ns1:Node recordCount="5.0">
+                                                            <ns1:True/>
+                                                            <ns1:Node recordCount="1.0" score="0.0">
+                                                                <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="-1.703312397"/>
+                                                            </ns1:Node>
+                                                            <ns1:Node recordCount="4.0" score="1.0">
+                                                                <ns1:True/>
+                                                            </ns1:Node>
+                                                        </ns1:Node>
+                                                    </ns1:Node>
+                                                </ns1:Node>
+                                                <ns1:Node recordCount="15.0">
+                                                    <ns1:True/>
+                                                    <ns1:Node recordCount="4.0">
+                                                        <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="0.024501575157"/>
+                                                        <ns1:Node recordCount="3.0" score="2.0">
+                                                            <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="-0.597128272057"/>
+                                                        </ns1:Node>
+                                                        <ns1:Node recordCount="1.0" score="1.0">
+                                                            <ns1:True/>
+                                                        </ns1:Node>
+                                                    </ns1:Node>
+                                                    <ns1:Node recordCount="11.0">
+                                                        <ns1:True/>
+                                                        <ns1:Node recordCount="3.0">
+                                                            <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="0.339357376099"/>
+                                                            <ns1:Node recordCount="2.0" score="0.0">
+                                                                <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="2.22920966148"/>
+                                                            </ns1:Node>
+                                                            <ns1:Node recordCount="1.0" score="1.0">
+                                                                <ns1:True/>
+                                                            </ns1:Node>
+                                                        </ns1:Node>
+                                                        <ns1:Node recordCount="8.0">
+                                                            <ns1:True/>
+                                                            <ns1:Node recordCount="6.0">
+                                                                <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="1.88006806374"/>
+                                                                <ns1:Node recordCount="1.0" score="0.0">
+                                                                    <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="-2.27075386047"/>
+                                                                </ns1:Node>
+                                                                <ns1:Node recordCount="5.0" score="1.0">
+                                                                    <ns1:True/>
+                                                                </ns1:Node>
+                                                            </ns1:Node>
+                                                            <ns1:Node recordCount="2.0" score="2.0">
+                                                                <ns1:True/>
+                                                            </ns1:Node>
+                                                        </ns1:Node>
+                                                    </ns1:Node>
+                                                </ns1:Node>
+                                            </ns1:Node>
+                                        </ns1:Node>
+                                    </ns1:Node>
+                                </ns1:Node>
+                                <ns1:Node recordCount="2.0" score="2.0">
+                                    <ns1:True/>
+                                </ns1:Node>
+                            </ns1:Node>
+                            <ns1:Node recordCount="70.0">
+                                <ns1:True/>
+                                <ns1:Node recordCount="49.0">
+                                    <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="0.352478563786"/>
+                                    <ns1:Node recordCount="37.0">
+                                        <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="0.0695974379778"/>
+                                        <ns1:Node recordCount="36.0">
+                                            <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="0.0678408890963"/>
+                                            <ns1:Node recordCount="1.0" score="2.0">
+                                                <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="-2.26362848282"/>
+                                            </ns1:Node>
+                                            <ns1:Node recordCount="35.0">
+                                                <ns1:True/>
+                                                <ns1:Node recordCount="24.0">
+                                                    <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="0.124081946909"/>
+                                                    <ns1:Node recordCount="4.0">
+                                                        <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="-0.167942032218"/>
+                                                        <ns1:Node recordCount="3.0">
+                                                            <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="-0.194218233228"/>
+                                                            <ns1:Node recordCount="2.0" score="1.0">
+                                                                <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="0.0343803539872"/>
+                                                            </ns1:Node>
+                                                            <ns1:Node recordCount="1.0" score="0.0">
+                                                                <ns1:True/>
+                                                            </ns1:Node>
+                                                        </ns1:Node>
+                                                        <ns1:Node recordCount="1.0" score="2.0">
+                                                            <ns1:True/>
+                                                        </ns1:Node>
+                                                    </ns1:Node>
+                                                    <ns1:Node recordCount="20.0">
+                                                        <ns1:True/>
+                                                        <ns1:Node recordCount="8.0">
+                                                            <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="-0.808284163475"/>
+                                                            <ns1:Node recordCount="3.0" score="0.0">
+                                                                <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="-0.524563372135"/>
+                                                            </ns1:Node>
+                                                            <ns1:Node recordCount="5.0">
+                                                                <ns1:True/>
+                                                                <ns1:Node recordCount="4.0" score="1.0">
+                                                                    <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="1.65988278389"/>
+                                                                </ns1:Node>
+                                                                <ns1:Node recordCount="1.0" score="0.0">
+                                                                    <ns1:True/>
+                                                                </ns1:Node>
+                                                            </ns1:Node>
+                                                        </ns1:Node>
+                                                        <ns1:Node recordCount="12.0" score="0.0">
+                                                            <ns1:True/>
+                                                        </ns1:Node>
+                                                    </ns1:Node>
+                                                </ns1:Node>
+                                                <ns1:Node recordCount="11.0">
+                                                    <ns1:True/>
+                                                    <ns1:Node recordCount="1.0" score="0.0">
+                                                        <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="-1.43221211433"/>
+                                                    </ns1:Node>
+                                                    <ns1:Node recordCount="10.0">
+                                                        <ns1:True/>
+                                                        <ns1:Node recordCount="9.0">
+                                                            <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="-0.0203964337707"/>
+                                                            <ns1:Node recordCount="7.0">
+                                                                <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="-0.306760489941"/>
+                                                                <ns1:Node recordCount="4.0" score="1.0">
+                                                                    <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="0.696138679981"/>
+                                                                </ns1:Node>
+                                                                <ns1:Node recordCount="3.0">
+                                                                    <ns1:True/>
+                                                                    <ns1:Node recordCount="1.0" score="0.0">
+                                                                        <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="1.00514674187"/>
+                                                                    </ns1:Node>
+                                                                    <ns1:Node recordCount="2.0" score="1.0">
+                                                                        <ns1:True/>
+                                                                    </ns1:Node>
+                                                                </ns1:Node>
+                                                            </ns1:Node>
+                                                            <ns1:Node recordCount="2.0">
+                                                                <ns1:True/>
+                                                                <ns1:Node recordCount="1.0" score="1.0">
+                                                                    <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="0.202191829681"/>
+                                                                </ns1:Node>
+                                                                <ns1:Node recordCount="1.0" score="2.0">
+                                                                    <ns1:True/>
+                                                                </ns1:Node>
+                                                            </ns1:Node>
+                                                        </ns1:Node>
+                                                        <ns1:Node recordCount="1.0" score="0.0">
+                                                            <ns1:True/>
+                                                        </ns1:Node>
+                                                    </ns1:Node>
+                                                </ns1:Node>
+                                            </ns1:Node>
+                                        </ns1:Node>
+                                        <ns1:Node recordCount="1.0" score="2.0">
+                                            <ns1:True/>
+                                        </ns1:Node>
+                                    </ns1:Node>
+                                    <ns1:Node recordCount="12.0">
+                                        <ns1:True/>
+                                        <ns1:Node recordCount="11.0" score="0.0">
+                                            <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="0.852672338486"/>
+                                        </ns1:Node>
+                                        <ns1:Node recordCount="1.0" score="1.0">
+                                            <ns1:True/>
+                                        </ns1:Node>
+                                    </ns1:Node>
+                                </ns1:Node>
+                                <ns1:Node recordCount="21.0">
+                                    <ns1:True/>
+                                    <ns1:Node recordCount="4.0">
+                                        <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="0.490969598293"/>
+                                        <ns1:Node recordCount="3.0" score="2.0">
+                                            <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="1.26509737968"/>
+                                        </ns1:Node>
+                                        <ns1:Node recordCount="1.0" score="1.0">
+                                            <ns1:True/>
+                                        </ns1:Node>
+                                    </ns1:Node>
+                                    <ns1:Node recordCount="17.0">
+                                        <ns1:True/>
+                                        <ns1:Node recordCount="14.0">
+                                            <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="1.11556339264"/>
+                                            <ns1:Node recordCount="6.0">
+                                                <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="0.713964223862"/>
+                                                <ns1:Node recordCount="4.0" score="0.0">
+                                                    <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="-0.0689894706011"/>
+                                                </ns1:Node>
+                                                <ns1:Node recordCount="2.0" score="1.0">
+                                                    <ns1:True/>
+                                                </ns1:Node>
+                                            </ns1:Node>
+                                            <ns1:Node recordCount="8.0">
+                                                <ns1:True/>
+                                                <ns1:Node recordCount="1.0" score="0.0">
+                                                    <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="-0.448789298534"/>
+                                                </ns1:Node>
+                                                <ns1:Node recordCount="7.0">
+                                                    <ns1:True/>
+                                                    <ns1:Node recordCount="5.0">
+                                                        <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="0.0547344312072"/>
+                                                        <ns1:Node recordCount="3.0" score="2.0">
+                                                            <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="0.987886250019"/>
+                                                        </ns1:Node>
+                                                        <ns1:Node recordCount="2.0" score="1.0">
+                                                            <ns1:True/>
+                                                        </ns1:Node>
+                                                    </ns1:Node>
+                                                    <ns1:Node recordCount="2.0" score="1.0">
+                                                        <ns1:True/>
+                                                    </ns1:Node>
+                                                </ns1:Node>
+                                            </ns1:Node>
+                                        </ns1:Node>
+                                        <ns1:Node recordCount="3.0" score="0.0">
+                                            <ns1:True/>
+                                        </ns1:Node>
+                                    </ns1:Node>
+                                </ns1:Node>
+                            </ns1:Node>
+                        </ns1:Node>
+                    </ns1:Node>
+                    <ns1:Node recordCount="111.0">
+                        <ns1:True/>
+                        <ns1:Node recordCount="73.0">
+                            <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="0.588179171085"/>
+                            <ns1:Node recordCount="52.0">
+                                <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="1.06017780304"/>
+                                <ns1:Node recordCount="35.0">
+                                    <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="0.784373760223"/>
+                                    <ns1:Node recordCount="6.0">
+                                        <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="0.282474786043"/>
+                                        <ns1:Node recordCount="3.0" score="0.0">
+                                            <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="-0.459563791752"/>
+                                        </ns1:Node>
+                                        <ns1:Node recordCount="3.0">
+                                            <ns1:True/>
+                                            <ns1:Node recordCount="1.0" score="0.0">
+                                                <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="-0.0706226676702"/>
+                                            </ns1:Node>
+                                            <ns1:Node recordCount="2.0" score="1.0">
+                                                <ns1:True/>
+                                            </ns1:Node>
+                                        </ns1:Node>
+                                    </ns1:Node>
+                                    <ns1:Node recordCount="29.0">
+                                        <ns1:True/>
+                                        <ns1:Node recordCount="27.0">
+                                            <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="0.754492998123"/>
+                                            <ns1:Node recordCount="1.0" score="0.0">
+                                                <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="-1.52648425102"/>
+                                            </ns1:Node>
+                                            <ns1:Node recordCount="26.0">
+                                                <ns1:True/>
+                                                <ns1:Node recordCount="3.0" score="2.0">
+                                                    <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="0.437738776207"/>
+                                                </ns1:Node>
+                                                <ns1:Node recordCount="23.0">
+                                                    <ns1:True/>
+                                                    <ns1:Node recordCount="2.0" score="0.0">
+                                                        <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="0.4742000103"/>
+                                                    </ns1:Node>
+                                                    <ns1:Node recordCount="21.0">
+                                                        <ns1:True/>
+                                                        <ns1:Node recordCount="19.0">
+                                                            <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="1.87857556343"/>
+                                                            <ns1:Node recordCount="17.0">
+                                                                <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="0.42531645298"/>
+                                                                <ns1:Node recordCount="16.0">
+                                                                    <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="0.736793518066"/>
+                                                                    <ns1:Node recordCount="1.0" score="2.0">
+                                                                        <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="-1.36132955551"/>
+                                                                    </ns1:Node>
+                                                                    <ns1:Node recordCount="15.0">
+                                                                        <ns1:True/>
+                                                                        <ns1:Node recordCount="13.0">
+                                                                            <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="0.84940469265"/>
+                                                                            <ns1:Node recordCount="2.0">
+                                                                                <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="0.415996819735"/>
+                                                                                <ns1:Node recordCount="1.0" score="2.0">
+                                                                                    <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="-0.302694261074"/>
+                                                                                </ns1:Node>
+                                                                                <ns1:Node recordCount="1.0" score="1.0">
+                                                                                    <ns1:True/>
+                                                                                </ns1:Node>
+                                                                            </ns1:Node>
+                                                                            <ns1:Node recordCount="11.0" score="1.0">
+                                                                                <ns1:True/>
+                                                                            </ns1:Node>
+                                                                        </ns1:Node>
+                                                                        <ns1:Node recordCount="2.0">
+                                                                            <ns1:True/>
+                                                                            <ns1:Node recordCount="1.0" score="2.0">
+                                                                                <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="1.17746770382"/>
+                                                                            </ns1:Node>
+                                                                            <ns1:Node recordCount="1.0" score="1.0">
+                                                                                <ns1:True/>
+                                                                            </ns1:Node>
+                                                                        </ns1:Node>
+                                                                    </ns1:Node>
+                                                                </ns1:Node>
+                                                                <ns1:Node recordCount="1.0" score="2.0">
+                                                                    <ns1:True/>
+                                                                </ns1:Node>
+                                                            </ns1:Node>
+                                                            <ns1:Node recordCount="2.0" score="2.0">
+                                                                <ns1:True/>
+                                                            </ns1:Node>
+                                                        </ns1:Node>
+                                                        <ns1:Node recordCount="2.0" score="2.0">
+                                                            <ns1:True/>
+                                                        </ns1:Node>
+                                                    </ns1:Node>
+                                                </ns1:Node>
+                                            </ns1:Node>
+                                        </ns1:Node>
+                                        <ns1:Node recordCount="2.0" score="0.0">
+                                            <ns1:True/>
+                                        </ns1:Node>
+                                    </ns1:Node>
+                                </ns1:Node>
+                                <ns1:Node recordCount="17.0">
+                                    <ns1:True/>
+                                    <ns1:Node recordCount="12.0">
+                                        <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="0.770356714725"/>
+                                        <ns1:Node recordCount="10.0" score="2.0">
+                                            <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="1.01729977131"/>
+                                        </ns1:Node>
+                                        <ns1:Node recordCount="2.0">
+                                            <ns1:True/>
+                                            <ns1:Node recordCount="1.0" score="1.0">
+                                                <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="0.708507061005"/>
+                                            </ns1:Node>
+                                            <ns1:Node recordCount="1.0" score="2.0">
+                                                <ns1:True/>
+                                            </ns1:Node>
+                                        </ns1:Node>
+                                    </ns1:Node>
+                                    <ns1:Node recordCount="5.0">
+                                        <ns1:True/>
+                                        <ns1:Node recordCount="3.0">
+                                            <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="0.82085198164"/>
+                                            <ns1:Node recordCount="2.0" score="1.0">
+                                                <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="1.38374221325"/>
+                                            </ns1:Node>
+                                            <ns1:Node recordCount="1.0" score="2.0">
+                                                <ns1:True/>
+                                            </ns1:Node>
+                                        </ns1:Node>
+                                        <ns1:Node recordCount="2.0" score="0.0">
+                                            <ns1:True/>
+                                        </ns1:Node>
+                                    </ns1:Node>
+                                </ns1:Node>
+                            </ns1:Node>
+                            <ns1:Node recordCount="21.0">
+                                <ns1:True/>
+                                <ns1:Node recordCount="7.0">
+                                    <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="1.21863865852"/>
+                                    <ns1:Node recordCount="1.0" score="1.0">
+                                        <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="1.07116675377"/>
+                                    </ns1:Node>
+                                    <ns1:Node recordCount="6.0">
+                                        <ns1:True/>
+                                        <ns1:Node recordCount="2.0">
+                                            <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="0.207697540522"/>
+                                            <ns1:Node recordCount="1.0" score="1.0">
+                                                <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="1.16794025898"/>
+                                            </ns1:Node>
+                                            <ns1:Node recordCount="1.0" score="0.0">
+                                                <ns1:True/>
+                                            </ns1:Node>
+                                        </ns1:Node>
+                                        <ns1:Node recordCount="4.0" score="0.0">
+                                            <ns1:True/>
+                                        </ns1:Node>
+                                    </ns1:Node>
+                                </ns1:Node>
+                                <ns1:Node recordCount="14.0">
+                                    <ns1:True/>
+                                    <ns1:Node recordCount="4.0" score="2.0">
+                                        <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="-0.941139698029"/>
+                                    </ns1:Node>
+                                    <ns1:Node recordCount="10.0">
+                                        <ns1:True/>
+                                        <ns1:Node recordCount="1.0" score="2.0">
+                                            <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="-0.117394290864"/>
+                                        </ns1:Node>
+                                        <ns1:Node recordCount="9.0">
+                                            <ns1:True/>
+                                            <ns1:Node recordCount="2.0" score="0.0">
+                                                <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="0.335132330656"/>
+                                            </ns1:Node>
+                                            <ns1:Node recordCount="7.0">
+                                                <ns1:True/>
+                                                <ns1:Node recordCount="6.0">
+                                                    <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="1.54234719276"/>
+                                                    <ns1:Node recordCount="4.0" score="1.0">
+                                                        <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="0.583711862564"/>
+                                                    </ns1:Node>
+                                                    <ns1:Node recordCount="2.0">
+                                                        <ns1:True/>
+                                                        <ns1:Node recordCount="1.0" score="0.0">
+                                                            <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="0.826062142849"/>
+                                                        </ns1:Node>
+                                                        <ns1:Node recordCount="1.0" score="1.0">
+                                                            <ns1:True/>
+                                                        </ns1:Node>
+                                                    </ns1:Node>
+                                                </ns1:Node>
+                                                <ns1:Node recordCount="1.0" score="0.0">
+                                                    <ns1:True/>
+                                                </ns1:Node>
+                                            </ns1:Node>
+                                        </ns1:Node>
+                                    </ns1:Node>
+                                </ns1:Node>
+                            </ns1:Node>
+                        </ns1:Node>
+                        <ns1:Node recordCount="38.0">
+                            <ns1:True/>
+                            <ns1:Node recordCount="8.0">
+                                <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="0.743154525757"/>
+                                <ns1:Node recordCount="7.0">
+                                    <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="1.44603049755"/>
+                                    <ns1:Node recordCount="2.0">
+                                        <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="0.636095166206"/>
+                                        <ns1:Node recordCount="1.0" score="0.0">
+                                            <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="-0.751208901405"/>
+                                        </ns1:Node>
+                                        <ns1:Node recordCount="1.0" score="1.0">
+                                            <ns1:True/>
+                                        </ns1:Node>
+                                    </ns1:Node>
+                                    <ns1:Node recordCount="5.0" score="0.0">
+                                        <ns1:True/>
+                                    </ns1:Node>
+                                </ns1:Node>
+                                <ns1:Node recordCount="1.0" score="2.0">
+                                    <ns1:True/>
+                                </ns1:Node>
+                            </ns1:Node>
+                            <ns1:Node recordCount="30.0">
+                                <ns1:True/>
+                                <ns1:Node recordCount="26.0">
+                                    <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="1.60058391094"/>
+                                    <ns1:Node recordCount="6.0">
+                                        <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="-1.13934159279"/>
+                                        <ns1:Node recordCount="4.0">
+                                            <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="-1.5557448864"/>
+                                            <ns1:Node recordCount="2.0">
+                                                <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="0.678086340427"/>
+                                                <ns1:Node recordCount="1.0" score="1.0">
+                                                    <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="-0.150913640857"/>
+                                                </ns1:Node>
+                                                <ns1:Node recordCount="1.0" score="0.0">
+                                                    <ns1:True/>
+                                                </ns1:Node>
+                                            </ns1:Node>
+                                            <ns1:Node recordCount="2.0" score="1.0">
+                                                <ns1:True/>
+                                            </ns1:Node>
+                                        </ns1:Node>
+                                        <ns1:Node recordCount="2.0" score="0.0">
+                                            <ns1:True/>
+                                        </ns1:Node>
+                                    </ns1:Node>
+                                    <ns1:Node recordCount="20.0">
+                                        <ns1:True/>
+                                        <ns1:Node recordCount="15.0">
+                                            <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="1.01761221886"/>
+                                            <ns1:Node recordCount="3.0">
+                                                <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="-0.951703429222"/>
+                                                <ns1:Node recordCount="1.0" score="1.0">
+                                                    <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="-1.08378219604"/>
+                                                </ns1:Node>
+                                                <ns1:Node recordCount="2.0" score="2.0">
+                                                    <ns1:True/>
+                                                </ns1:Node>
+                                            </ns1:Node>
+                                            <ns1:Node recordCount="12.0">
+                                                <ns1:True/>
+                                                <ns1:Node recordCount="2.0" score="0.0">
+                                                    <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="0.265864282846"/>
+                                                </ns1:Node>
+                                                <ns1:Node recordCount="10.0">
+                                                    <ns1:True/>
+                                                    <ns1:Node recordCount="8.0">
+                                                        <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="1.38179004192"/>
+                                                        <ns1:Node recordCount="4.0">
+                                                            <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="1.1224899292"/>
+                                                            <ns1:Node recordCount="1.0" score="1.0">
+                                                                <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="1.02121663094"/>
+                                                            </ns1:Node>
+                                                            <ns1:Node recordCount="3.0" score="0.0">
+                                                                <ns1:True/>
+                                                            </ns1:Node>
+                                                        </ns1:Node>
+                                                        <ns1:Node recordCount="4.0" score="1.0">
+                                                            <ns1:True/>
+                                                        </ns1:Node>
+                                                    </ns1:Node>
+                                                    <ns1:Node recordCount="2.0">
+                                                        <ns1:True/>
+                                                        <ns1:Node recordCount="1.0" score="1.0">
+                                                            <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="0.483509004116"/>
+                                                        </ns1:Node>
+                                                        <ns1:Node recordCount="1.0" score="2.0">
+                                                            <ns1:True/>
+                                                        </ns1:Node>
+                                                    </ns1:Node>
+                                                </ns1:Node>
+                                            </ns1:Node>
+                                        </ns1:Node>
+                                        <ns1:Node recordCount="5.0">
+                                            <ns1:True/>
+                                            <ns1:Node recordCount="3.0" score="2.0">
+                                                <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="1.19180452824"/>
+                                            </ns1:Node>
+                                            <ns1:Node recordCount="2.0" score="1.0">
+                                                <ns1:True/>
+                                            </ns1:Node>
+                                        </ns1:Node>
+                                    </ns1:Node>
+                                </ns1:Node>
+                                <ns1:Node recordCount="4.0">
+                                    <ns1:True/>
+                                    <ns1:Node recordCount="1.0" score="1.0">
+                                        <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="0.43673145771"/>
+                                    </ns1:Node>
+                                    <ns1:Node recordCount="3.0" score="0.0">
+                                        <ns1:True/>
+                                    </ns1:Node>
+                                </ns1:Node>
+                            </ns1:Node>
+                        </ns1:Node>
+                    </ns1:Node>
+                </ns1:Node>
+                <ns1:Node recordCount="32.0">
+                    <ns1:True/>
+                    <ns1:Node recordCount="12.0">
+                        <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="1.51424646378"/>
+                        <ns1:Node recordCount="10.0">
+                            <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="1.26997327805"/>
+                            <ns1:Node recordCount="1.0" score="1.0">
+                                <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="-1.3665920496"/>
+                            </ns1:Node>
+                            <ns1:Node recordCount="9.0">
+                                <ns1:True/>
+                                <ns1:Node recordCount="4.0">
+                                    <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="1.33888733387"/>
+                                    <ns1:Node recordCount="2.0" score="2.0">
+                                        <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="1.3136575222"/>
+                                    </ns1:Node>
+                                    <ns1:Node recordCount="2.0" score="1.0">
+                                        <ns1:True/>
+                                    </ns1:Node>
+                                </ns1:Node>
+                                <ns1:Node recordCount="5.0" score="2.0">
+                                    <ns1:True/>
+                                </ns1:Node>
+                            </ns1:Node>
+                        </ns1:Node>
+                        <ns1:Node recordCount="2.0">
+                            <ns1:True/>
+                            <ns1:Node recordCount="1.0" score="0.0">
+                                <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="1.6827403307"/>
+                            </ns1:Node>
+                            <ns1:Node recordCount="1.0" score="2.0">
+                                <ns1:True/>
+                            </ns1:Node>
+                        </ns1:Node>
+                    </ns1:Node>
+                    <ns1:Node recordCount="20.0">
+                        <ns1:True/>
+                        <ns1:Node recordCount="7.0">
+                            <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="1.85017621517"/>
+                            <ns1:Node recordCount="2.0" score="1.0">
+                                <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="1.58874678612"/>
+                            </ns1:Node>
+                            <ns1:Node recordCount="5.0">
+                                <ns1:True/>
+                                <ns1:Node recordCount="2.0" score="0.0">
+                                    <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="1.67728686333"/>
+                                </ns1:Node>
+                                <ns1:Node recordCount="3.0">
+                                    <ns1:True/>
+                                    <ns1:Node recordCount="2.0" score="1.0">
+                                        <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="-0.175021722913"/>
+                                    </ns1:Node>
+                                    <ns1:Node recordCount="1.0" score="0.0">
+                                        <ns1:True/>
+                                    </ns1:Node>
+                                </ns1:Node>
+                            </ns1:Node>
+                        </ns1:Node>
+                        <ns1:Node recordCount="13.0">
+                            <ns1:True/>
+                            <ns1:Node recordCount="7.0">
+                                <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="2.06933426857"/>
+                                <ns1:Node recordCount="5.0">
+                                    <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="0.741447031498"/>
+                                    <ns1:Node recordCount="2.0" score="2.0">
+                                        <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="1.91326642036"/>
+                                    </ns1:Node>
+                                    <ns1:Node recordCount="3.0" score="1.0">
+                                        <ns1:True/>
+                                    </ns1:Node>
+                                </ns1:Node>
+                                <ns1:Node recordCount="2.0" score="2.0">
+                                    <ns1:True/>
+                                </ns1:Node>
+                            </ns1:Node>
+                            <ns1:Node recordCount="6.0">
+                                <ns1:True/>
+                                <ns1:Node recordCount="3.0">
+                                    <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="-0.480090975761"/>
+                                    <ns1:Node recordCount="2.0" score="0.0">
+                                        <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="2.56281757355"/>
+                                    </ns1:Node>
+                                    <ns1:Node recordCount="1.0" score="1.0">
+                                        <ns1:True/>
+                                    </ns1:Node>
+                                </ns1:Node>
+                                <ns1:Node recordCount="3.0" score="1.0">
+                                    <ns1:True/>
+                                </ns1:Node>
+                            </ns1:Node>
+                        </ns1:Node>
+                    </ns1:Node>
+                </ns1:Node>
+            </ns1:Node>
+        </ns1:Node>
+    </ns1:TreeModel>
+</ns1:PMML>

--- a/examples/pmml/GradientBoostingClassifier.pmml
+++ b/examples/pmml/GradientBoostingClassifier.pmml
@@ -1,0 +1,145 @@
+<?xml version="1.0" ?>
+<ns1:PMML xmlns:ns1="http://www.dmg.org/PMML-4_2" version="4.2">
+    <ns1:Header/>
+    <ns1:DataDictionary>
+        <ns1:DataField dataType="string" name="internal::y" optype="categorical">
+            <ns1:Value value="negative"/>
+            <ns1:Value value="positive"/>
+        </ns1:DataField>
+        <ns1:DataField dataType="string" name="y" optype="categorical">
+            <ns1:Value value="negative"/>
+            <ns1:Value value="positive"/>
+        </ns1:DataField>
+        <ns1:DataField dataType="double" name="col_0" optype="continuous"/>
+        <ns1:DataField dataType="double" name="col_1" optype="continuous"/>
+        <ns1:DataField dataType="double" name="col_2" optype="continuous"/>
+        <ns1:DataField dataType="double" name="col_3" optype="continuous"/>
+    </ns1:DataDictionary>
+    <ns1:TransformationDictionary/>
+    <ns1:MiningModel functionName="regression">
+        <ns1:MiningSchema>
+            <ns1:MiningField invalidValueTreatment="asIs" name="col_0"/>
+            <ns1:MiningField invalidValueTreatment="asIs" name="col_1"/>
+            <ns1:MiningField invalidValueTreatment="asIs" name="col_2"/>
+            <ns1:MiningField invalidValueTreatment="asIs" name="col_3"/>
+        </ns1:MiningSchema>
+        <ns1:Output>
+            <ns1:OutputField feature="predictedValue" name="internal::y"/>
+            <ns1:OutputField dataType="double" feature="transformedValue" name="y::positive" optype="continuous">
+                <ns1:Apply function="/">
+                    <ns1:Constant dataType="double">1.0</ns1:Constant>
+                    <ns1:Apply function="+">
+                        <ns1:Constant dataType="double">1.0</ns1:Constant>
+                        <ns1:Apply function="exp">
+                            <ns1:Apply function="*">
+                                <ns1:Constant dataType="double">-1.2</ns1:Constant>
+                                <ns1:FieldRef field="internal::y"/>
+                            </ns1:Apply>
+                        </ns1:Apply>
+                    </ns1:Apply>
+                </ns1:Apply>
+            </ns1:OutputField>
+            <ns1:OutputField dataType="double" feature="transformedValue" name="y::negative" optype="continuous">
+                <ns1:Apply function="-">
+                    <ns1:Constant dataType="double">1</ns1:Constant>
+                    <ns1:FieldRef field="y::positive"/>
+                </ns1:Apply>
+            </ns1:OutputField>
+            <ns1:OutputField dataType="string" feature="transformedValue" name="y" optype="categorical">
+                <ns1:Discretize field="internal::y">
+                    <ns1:DiscretizeBin binValue="negative">
+                        <ns1:Interval closure="openOpen" rightMargin="0.0"/>
+                    </ns1:DiscretizeBin>
+                    <ns1:DiscretizeBin binValue="positive">
+                        <ns1:Interval closure="closedOpen" leftMargin="0.0"/>
+                    </ns1:DiscretizeBin>
+                </ns1:Discretize>
+            </ns1:OutputField>
+        </ns1:Output>
+        <ns1:Segmentation multipleModelMethod="weightedAverage">
+            <ns1:Segment weight="1.0">
+                <ns1:True/>
+                <ns1:RegressionModel algorithmName="linearRegression" functionName="regression">
+                    <ns1:MiningSchema>
+                        <ns1:MiningField invalidValueTreatment="asIs" name="col_0"/>
+                        <ns1:MiningField invalidValueTreatment="asIs" name="col_1"/>
+                        <ns1:MiningField invalidValueTreatment="asIs" name="col_2"/>
+                        <ns1:MiningField invalidValueTreatment="asIs" name="col_3"/>
+                        <ns1:MiningField name="internal::y" usageType="predicted"/>
+                    </ns1:MiningSchema>
+                    <ns1:RegressionTable intercept="0.104093891043"/>
+                </ns1:RegressionModel>
+            </ns1:Segment>
+            <ns1:Segment weight="0.1">
+                <ns1:True/>
+                <ns1:TreeModel functionName="regression" splitCharacteristic="binarySplit">
+                    <ns1:MiningSchema>
+                        <ns1:MiningField invalidValueTreatment="asIs" name="col_0"/>
+                        <ns1:MiningField invalidValueTreatment="asIs" name="col_1"/>
+                        <ns1:MiningField invalidValueTreatment="asIs" name="col_2"/>
+                        <ns1:MiningField invalidValueTreatment="asIs" name="col_3"/>
+                    </ns1:MiningSchema>
+                    <ns1:Output>
+                        <ns1:OutputField dataType="double" feature="predictedValue" name="('numeric', False, False)::y" optype="continuous"/>
+                    </ns1:Output>
+                    <ns1:Node recordCount="500.0">
+                        <ns1:True/>
+                        <ns1:Node recordCount="280.0">
+                            <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="0.155709639192"/>
+                            <ns1:Node recordCount="55.0" score="-1.01583773432">
+                                <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="-0.81821501255"/>
+                            </ns1:Node>
+                            <ns1:Node recordCount="225.0" score="-0.0775430096314">
+                                <ns1:True/>
+                            </ns1:Node>
+                        </ns1:Node>
+                        <ns1:Node recordCount="220.0">
+                            <ns1:True/>
+                            <ns1:Node recordCount="78.0" score="0.97556099385">
+                                <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="0.628501057625"/>
+                            </ns1:Node>
+                            <ns1:Node recordCount="142.0" score="-0.0195458096157">
+                                <ns1:True/>
+                            </ns1:Node>
+                        </ns1:Node>
+                    </ns1:Node>
+                </ns1:TreeModel>
+            </ns1:Segment>
+            <ns1:Segment weight="0.1">
+                <ns1:True/>
+                <ns1:TreeModel functionName="regression" splitCharacteristic="binarySplit">
+                    <ns1:MiningSchema>
+                        <ns1:MiningField invalidValueTreatment="asIs" name="col_0"/>
+                        <ns1:MiningField invalidValueTreatment="asIs" name="col_1"/>
+                        <ns1:MiningField invalidValueTreatment="asIs" name="col_2"/>
+                        <ns1:MiningField invalidValueTreatment="asIs" name="col_3"/>
+                    </ns1:MiningSchema>
+                    <ns1:Output>
+                        <ns1:OutputField dataType="double" feature="predictedValue" name="('numeric', False, False)::y" optype="continuous"/>
+                    </ns1:Output>
+                    <ns1:Node recordCount="500.0">
+                        <ns1:True/>
+                        <ns1:Node recordCount="176.0">
+                            <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="-0.457421511412"/>
+                            <ns1:Node recordCount="152.0" score="-0.235672493053">
+                                <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="-0.541861891747"/>
+                            </ns1:Node>
+                            <ns1:Node recordCount="24.0" score="-1.28228877166">
+                                <ns1:True/>
+                            </ns1:Node>
+                        </ns1:Node>
+                        <ns1:Node recordCount="324.0">
+                            <ns1:True/>
+                            <ns1:Node recordCount="142.0" score="0.555457948501">
+                                <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="0.346540868282"/>
+                            </ns1:Node>
+                            <ns1:Node recordCount="182.0" score="-0.0667138520138">
+                                <ns1:True/>
+                            </ns1:Node>
+                        </ns1:Node>
+                    </ns1:Node>
+                </ns1:TreeModel>
+            </ns1:Segment>
+        </ns1:Segmentation>
+    </ns1:MiningModel>
+</ns1:PMML>

--- a/examples/pmml/RandomForestClassifier.pmml
+++ b/examples/pmml/RandomForestClassifier.pmml
@@ -1,0 +1,350 @@
+<?xml version="1.0" ?>
+<ns1:PMML xmlns:ns1="http://www.dmg.org/PMML-4_2" version="4.2">
+    <ns1:Header/>
+    <ns1:DataDictionary>
+        <ns1:DataField dataType="integer" name="internal::y" optype="categorical">
+            <ns1:Value value="0"/>
+            <ns1:Value value="1"/>
+            <ns1:Value value="2"/>
+        </ns1:DataField>
+        <ns1:DataField dataType="integer" name="y" optype="categorical">
+            <ns1:Value value="0"/>
+            <ns1:Value value="1"/>
+            <ns1:Value value="2"/>
+        </ns1:DataField>
+        <ns1:DataField dataType="double" name="col_0" optype="continuous"/>
+        <ns1:DataField dataType="double" name="col_1" optype="continuous"/>
+        <ns1:DataField dataType="double" name="col_2" optype="continuous"/>
+        <ns1:DataField dataType="double" name="col_3" optype="continuous"/>
+    </ns1:DataDictionary>
+    <ns1:TransformationDictionary/>
+    <ns1:MiningModel functionName="classification">
+        <ns1:MiningSchema>
+            <ns1:MiningField invalidValueTreatment="asIs" name="col_0"/>
+            <ns1:MiningField invalidValueTreatment="asIs" name="col_1"/>
+            <ns1:MiningField invalidValueTreatment="asIs" name="col_2"/>
+            <ns1:MiningField invalidValueTreatment="asIs" name="col_3"/>
+            <ns1:MiningField name="internal::y" usageType="predicted"/>
+        </ns1:MiningSchema>
+        <ns1:Output>
+            <ns1:OutputField dataType="integer" feature="predictedValue" name="y" optype="categorical"/>
+            <ns1:OutputField dataType="double" feature="probability" name="y::0" optype="continuous" targetField="internal::y" value="0"/>
+            <ns1:OutputField dataType="double" feature="probability" name="y::1" optype="continuous" targetField="internal::y" value="1"/>
+            <ns1:OutputField dataType="double" feature="probability" name="y::2" optype="continuous" targetField="internal::y" value="2"/>
+        </ns1:Output>
+        <ns1:Segmentation multipleModelMethod="weightedAverage">
+            <ns1:Segment id="0">
+                <ns1:True/>
+                <ns1:TreeModel functionName="classification" splitCharacteristic="binarySplit">
+                    <ns1:MiningSchema>
+                        <ns1:MiningField invalidValueTreatment="asIs" name="col_0"/>
+                        <ns1:MiningField invalidValueTreatment="asIs" name="col_1"/>
+                        <ns1:MiningField invalidValueTreatment="asIs" name="col_2"/>
+                        <ns1:MiningField invalidValueTreatment="asIs" name="col_3"/>
+                        <ns1:MiningField name="internal::y" usageType="predicted"/>
+                    </ns1:MiningSchema>
+                    <ns1:Output>
+                        <ns1:OutputField dataType="integer" feature="predictedValue" name="y" optype="categorical"/>
+                        <ns1:OutputField dataType="double" feature="probability" name="y::0" optype="continuous" targetField="internal::y" value="0"/>
+                        <ns1:OutputField dataType="double" feature="probability" name="y::1" optype="continuous" targetField="internal::y" value="1"/>
+                        <ns1:OutputField dataType="double" feature="probability" name="y::2" optype="continuous" targetField="internal::y" value="2"/>
+                    </ns1:Output>
+                    <ns1:Node recordCount="321.0" score="0">
+                        <ns1:True/>
+                        <ns1:ScoreDistribution confidence="0.535825545171" recordCount="172.0" value="0"/>
+                        <ns1:ScoreDistribution confidence="0.489096573209" recordCount="157.0" value="1"/>
+                        <ns1:ScoreDistribution confidence="0.532710280374" recordCount="171.0" value="2"/>
+                        <ns1:Node recordCount="11.0" score="1">
+                            <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="-2.0007185936"/>
+                            <ns1:ScoreDistribution confidence="0.0" recordCount="0.0" value="0"/>
+                            <ns1:ScoreDistribution confidence="1.27272727273" recordCount="14.0" value="1"/>
+                            <ns1:ScoreDistribution confidence="0.181818181818" recordCount="2.0" value="2"/>
+                            <ns1:Node recordCount="9.0" score="1">
+                                <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="0.638656973839"/>
+                                <ns1:ScoreDistribution confidence="0.0" recordCount="0.0" value="0"/>
+                                <ns1:ScoreDistribution confidence="1.0" recordCount="12.0" value="1"/>
+                                <ns1:ScoreDistribution confidence="0.0" recordCount="0.0" value="2"/>
+                            </ns1:Node>
+                            <ns1:Node recordCount="2.0" score="1">
+                                <ns1:True/>
+                                <ns1:ScoreDistribution confidence="0.0" recordCount="0.0" value="0"/>
+                                <ns1:ScoreDistribution confidence="1.0" recordCount="2.0" value="1"/>
+                                <ns1:ScoreDistribution confidence="1.0" recordCount="2.0" value="2"/>
+                                <ns1:Node recordCount="1.0" score="1">
+                                    <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="-0.382083296776"/>
+                                    <ns1:ScoreDistribution confidence="0.0" recordCount="0.0" value="0"/>
+                                    <ns1:ScoreDistribution confidence="1.0" recordCount="2.0" value="1"/>
+                                    <ns1:ScoreDistribution confidence="0.0" recordCount="0.0" value="2"/>
+                                </ns1:Node>
+                                <ns1:Node recordCount="1.0" score="2">
+                                    <ns1:True/>
+                                    <ns1:ScoreDistribution confidence="0.0" recordCount="0.0" value="0"/>
+                                    <ns1:ScoreDistribution confidence="0.0" recordCount="0.0" value="1"/>
+                                    <ns1:ScoreDistribution confidence="1.0" recordCount="2.0" value="2"/>
+                                </ns1:Node>
+                            </ns1:Node>
+                        </ns1:Node>
+                        <ns1:Node recordCount="310.0" score="0">
+                            <ns1:True/>
+                            <ns1:ScoreDistribution confidence="0.554838709677" recordCount="172.0" value="0"/>
+                            <ns1:ScoreDistribution confidence="0.461290322581" recordCount="143.0" value="1"/>
+                            <ns1:ScoreDistribution confidence="0.545161290323" recordCount="169.0" value="2"/>
+                            <ns1:Node recordCount="252.0" score="2">
+                                <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="0.997073411942"/>
+                                <ns1:ScoreDistribution confidence="0.575396825397" recordCount="145.0" value="0"/>
+                                <ns1:ScoreDistribution confidence="0.428571428571" recordCount="108.0" value="1"/>
+                                <ns1:ScoreDistribution confidence="0.587301587302" recordCount="148.0" value="2"/>
+                                <ns1:Node recordCount="217.0" score="2">
+                                    <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="1.07116675377"/>
+                                    <ns1:ScoreDistribution confidence="0.31884057971" recordCount="110.0" value="0"/>
+                                    <ns1:ScoreDistribution confidence="0.28115942029" recordCount="97.0" value="1"/>
+                                    <ns1:ScoreDistribution confidence="0.4" recordCount="138.0" value="2"/>
+                                </ns1:Node>
+                                <ns1:Node recordCount="35.0" score="0">
+                                    <ns1:True/>
+                                    <ns1:ScoreDistribution confidence="0.625" recordCount="35.0" value="0"/>
+                                    <ns1:ScoreDistribution confidence="0.196428571429" recordCount="11.0" value="1"/>
+                                    <ns1:ScoreDistribution confidence="0.178571428571" recordCount="10.0" value="2"/>
+                                </ns1:Node>
+                            </ns1:Node>
+                            <ns1:Node recordCount="58.0" score="1">
+                                <ns1:True/>
+                                <ns1:ScoreDistribution confidence="0.465517241379" recordCount="27.0" value="0"/>
+                                <ns1:ScoreDistribution confidence="0.603448275862" recordCount="35.0" value="1"/>
+                                <ns1:ScoreDistribution confidence="0.362068965517" recordCount="21.0" value="2"/>
+                                <ns1:Node recordCount="34.0" score="1">
+                                    <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="1.56480169296"/>
+                                    <ns1:ScoreDistribution confidence="0.291666666667" recordCount="14.0" value="0"/>
+                                    <ns1:ScoreDistribution confidence="0.520833333333" recordCount="25.0" value="1"/>
+                                    <ns1:ScoreDistribution confidence="0.1875" recordCount="9.0" value="2"/>
+                                </ns1:Node>
+                                <ns1:Node recordCount="24.0" score="0">
+                                    <ns1:True/>
+                                    <ns1:ScoreDistribution confidence="0.371428571429" recordCount="13.0" value="0"/>
+                                    <ns1:ScoreDistribution confidence="0.285714285714" recordCount="10.0" value="1"/>
+                                    <ns1:ScoreDistribution confidence="0.342857142857" recordCount="12.0" value="2"/>
+                                </ns1:Node>
+                            </ns1:Node>
+                        </ns1:Node>
+                    </ns1:Node>
+                </ns1:TreeModel>
+            </ns1:Segment>
+            <ns1:Segment id="1">
+                <ns1:True/>
+                <ns1:TreeModel functionName="classification" splitCharacteristic="binarySplit">
+                    <ns1:MiningSchema>
+                        <ns1:MiningField invalidValueTreatment="asIs" name="col_0"/>
+                        <ns1:MiningField invalidValueTreatment="asIs" name="col_1"/>
+                        <ns1:MiningField invalidValueTreatment="asIs" name="col_2"/>
+                        <ns1:MiningField invalidValueTreatment="asIs" name="col_3"/>
+                        <ns1:MiningField name="internal::y" usageType="predicted"/>
+                    </ns1:MiningSchema>
+                    <ns1:Output>
+                        <ns1:OutputField dataType="integer" feature="predictedValue" name="y" optype="categorical"/>
+                        <ns1:OutputField dataType="double" feature="probability" name="y::0" optype="continuous" targetField="internal::y" value="0"/>
+                        <ns1:OutputField dataType="double" feature="probability" name="y::1" optype="continuous" targetField="internal::y" value="1"/>
+                        <ns1:OutputField dataType="double" feature="probability" name="y::2" optype="continuous" targetField="internal::y" value="2"/>
+                    </ns1:Output>
+                    <ns1:Node recordCount="336.0" score="1">
+                        <ns1:True/>
+                        <ns1:ScoreDistribution confidence="0.449404761905" recordCount="151.0" value="0"/>
+                        <ns1:ScoreDistribution confidence="0.5625" recordCount="189.0" value="1"/>
+                        <ns1:ScoreDistribution confidence="0.47619047619" recordCount="160.0" value="2"/>
+                        <ns1:Node recordCount="12.0" score="1">
+                            <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="-1.92965960503"/>
+                            <ns1:ScoreDistribution confidence="0.0" recordCount="0.0" value="0"/>
+                            <ns1:ScoreDistribution confidence="1.41666666667" recordCount="17.0" value="1"/>
+                            <ns1:ScoreDistribution confidence="0.166666666667" recordCount="2.0" value="2"/>
+                            <ns1:Node recordCount="10.0" score="1">
+                                <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="0.709010601044"/>
+                                <ns1:ScoreDistribution confidence="0.0" recordCount="0.0" value="0"/>
+                                <ns1:ScoreDistribution confidence="1.6" recordCount="16.0" value="1"/>
+                                <ns1:ScoreDistribution confidence="0.1" recordCount="1.0" value="2"/>
+                                <ns1:Node recordCount="3.0" score="1">
+                                    <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="-1.03807127476"/>
+                                    <ns1:ScoreDistribution confidence="0.0" recordCount="0.0" value="0"/>
+                                    <ns1:ScoreDistribution confidence="0.8" recordCount="4.0" value="1"/>
+                                    <ns1:ScoreDistribution confidence="0.2" recordCount="1.0" value="2"/>
+                                </ns1:Node>
+                                <ns1:Node recordCount="7.0" score="1">
+                                    <ns1:True/>
+                                    <ns1:ScoreDistribution confidence="0.0" recordCount="0.0" value="0"/>
+                                    <ns1:ScoreDistribution confidence="1.0" recordCount="12.0" value="1"/>
+                                    <ns1:ScoreDistribution confidence="0.0" recordCount="0.0" value="2"/>
+                                </ns1:Node>
+                            </ns1:Node>
+                            <ns1:Node recordCount="2.0" score="1">
+                                <ns1:True/>
+                                <ns1:ScoreDistribution confidence="0.0" recordCount="0.0" value="0"/>
+                                <ns1:ScoreDistribution confidence="0.5" recordCount="1.0" value="1"/>
+                                <ns1:ScoreDistribution confidence="0.5" recordCount="1.0" value="2"/>
+                                <ns1:Node recordCount="1.0" score="1">
+                                    <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="-2.05933618546"/>
+                                    <ns1:ScoreDistribution confidence="0.0" recordCount="0.0" value="0"/>
+                                    <ns1:ScoreDistribution confidence="1.0" recordCount="1.0" value="1"/>
+                                    <ns1:ScoreDistribution confidence="0.0" recordCount="0.0" value="2"/>
+                                </ns1:Node>
+                                <ns1:Node recordCount="1.0" score="2">
+                                    <ns1:True/>
+                                    <ns1:ScoreDistribution confidence="0.0" recordCount="0.0" value="0"/>
+                                    <ns1:ScoreDistribution confidence="0.0" recordCount="0.0" value="1"/>
+                                    <ns1:ScoreDistribution confidence="1.0" recordCount="1.0" value="2"/>
+                                </ns1:Node>
+                            </ns1:Node>
+                        </ns1:Node>
+                        <ns1:Node recordCount="324.0" score="1">
+                            <ns1:True/>
+                            <ns1:ScoreDistribution confidence="0.466049382716" recordCount="151.0" value="0"/>
+                            <ns1:ScoreDistribution confidence="0.530864197531" recordCount="172.0" value="1"/>
+                            <ns1:ScoreDistribution confidence="0.487654320988" recordCount="158.0" value="2"/>
+                            <ns1:Node recordCount="290.0" score="2">
+                                <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="1.3240275383"/>
+                                <ns1:ScoreDistribution confidence="0.472413793103" recordCount="137.0" value="0"/>
+                                <ns1:ScoreDistribution confidence="0.506896551724" recordCount="147.0" value="1"/>
+                                <ns1:ScoreDistribution confidence="0.520689655172" recordCount="151.0" value="2"/>
+                                <ns1:Node recordCount="279.0" score="2">
+                                    <ns1:SimplePredicate field="col_3" operator="lessOrEqual" value="1.9689218998"/>
+                                    <ns1:ScoreDistribution confidence="0.313397129187" recordCount="131.0" value="0"/>
+                                    <ns1:ScoreDistribution confidence="0.327751196172" recordCount="137.0" value="1"/>
+                                    <ns1:ScoreDistribution confidence="0.358851674641" recordCount="150.0" value="2"/>
+                                </ns1:Node>
+                                <ns1:Node recordCount="11.0" score="1">
+                                    <ns1:True/>
+                                    <ns1:ScoreDistribution confidence="0.352941176471" recordCount="6.0" value="0"/>
+                                    <ns1:ScoreDistribution confidence="0.588235294118" recordCount="10.0" value="1"/>
+                                    <ns1:ScoreDistribution confidence="0.0588235294118" recordCount="1.0" value="2"/>
+                                </ns1:Node>
+                            </ns1:Node>
+                            <ns1:Node recordCount="34.0" score="1">
+                                <ns1:True/>
+                                <ns1:ScoreDistribution confidence="0.411764705882" recordCount="14.0" value="0"/>
+                                <ns1:ScoreDistribution confidence="0.735294117647" recordCount="25.0" value="1"/>
+                                <ns1:ScoreDistribution confidence="0.205882352941" recordCount="7.0" value="2"/>
+                                <ns1:Node recordCount="2.0" score="1">
+                                    <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="1.34579753876"/>
+                                    <ns1:ScoreDistribution confidence="0.0" recordCount="0.0" value="0"/>
+                                    <ns1:ScoreDistribution confidence="1.0" recordCount="4.0" value="1"/>
+                                    <ns1:ScoreDistribution confidence="0.0" recordCount="0.0" value="2"/>
+                                </ns1:Node>
+                                <ns1:Node recordCount="32.0" score="1">
+                                    <ns1:True/>
+                                    <ns1:ScoreDistribution confidence="0.333333333333" recordCount="14.0" value="0"/>
+                                    <ns1:ScoreDistribution confidence="0.5" recordCount="21.0" value="1"/>
+                                    <ns1:ScoreDistribution confidence="0.166666666667" recordCount="7.0" value="2"/>
+                                </ns1:Node>
+                            </ns1:Node>
+                        </ns1:Node>
+                    </ns1:Node>
+                </ns1:TreeModel>
+            </ns1:Segment>
+            <ns1:Segment id="2">
+                <ns1:True/>
+                <ns1:TreeModel functionName="classification" splitCharacteristic="binarySplit">
+                    <ns1:MiningSchema>
+                        <ns1:MiningField invalidValueTreatment="asIs" name="col_0"/>
+                        <ns1:MiningField invalidValueTreatment="asIs" name="col_1"/>
+                        <ns1:MiningField invalidValueTreatment="asIs" name="col_2"/>
+                        <ns1:MiningField invalidValueTreatment="asIs" name="col_3"/>
+                        <ns1:MiningField name="internal::y" usageType="predicted"/>
+                    </ns1:MiningSchema>
+                    <ns1:Output>
+                        <ns1:OutputField dataType="integer" feature="predictedValue" name="y" optype="categorical"/>
+                        <ns1:OutputField dataType="double" feature="probability" name="y::0" optype="continuous" targetField="internal::y" value="0"/>
+                        <ns1:OutputField dataType="double" feature="probability" name="y::1" optype="continuous" targetField="internal::y" value="1"/>
+                        <ns1:OutputField dataType="double" feature="probability" name="y::2" optype="continuous" targetField="internal::y" value="2"/>
+                    </ns1:Output>
+                    <ns1:Node recordCount="321.0" score="1">
+                        <ns1:True/>
+                        <ns1:ScoreDistribution confidence="0.510903426791" recordCount="164.0" value="0"/>
+                        <ns1:ScoreDistribution confidence="0.570093457944" recordCount="183.0" value="1"/>
+                        <ns1:ScoreDistribution confidence="0.476635514019" recordCount="153.0" value="2"/>
+                        <ns1:Node recordCount="21.0" score="1">
+                            <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="-1.47007727623"/>
+                            <ns1:ScoreDistribution confidence="0.333333333333" recordCount="7.0" value="0"/>
+                            <ns1:ScoreDistribution confidence="1.19047619048" recordCount="25.0" value="1"/>
+                            <ns1:ScoreDistribution confidence="0.190476190476" recordCount="4.0" value="2"/>
+                            <ns1:Node recordCount="6.0" score="0">
+                                <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="-2.19679045677"/>
+                                <ns1:ScoreDistribution confidence="0.833333333333" recordCount="5.0" value="0"/>
+                                <ns1:ScoreDistribution confidence="0.5" recordCount="3.0" value="1"/>
+                                <ns1:ScoreDistribution confidence="0.333333333333" recordCount="2.0" value="2"/>
+                                <ns1:Node recordCount="2.0" score="1">
+                                    <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="0.17954005301"/>
+                                    <ns1:ScoreDistribution confidence="0.0" recordCount="0.0" value="0"/>
+                                    <ns1:ScoreDistribution confidence="1.0" recordCount="3.0" value="1"/>
+                                    <ns1:ScoreDistribution confidence="0.0" recordCount="0.0" value="2"/>
+                                </ns1:Node>
+                                <ns1:Node recordCount="4.0" score="0">
+                                    <ns1:True/>
+                                    <ns1:ScoreDistribution confidence="0.714285714286" recordCount="5.0" value="0"/>
+                                    <ns1:ScoreDistribution confidence="0.0" recordCount="0.0" value="1"/>
+                                    <ns1:ScoreDistribution confidence="0.285714285714" recordCount="2.0" value="2"/>
+                                </ns1:Node>
+                            </ns1:Node>
+                            <ns1:Node recordCount="15.0" score="1">
+                                <ns1:True/>
+                                <ns1:ScoreDistribution confidence="0.133333333333" recordCount="2.0" value="0"/>
+                                <ns1:ScoreDistribution confidence="1.46666666667" recordCount="22.0" value="1"/>
+                                <ns1:ScoreDistribution confidence="0.133333333333" recordCount="2.0" value="2"/>
+                                <ns1:Node recordCount="12.0" score="1">
+                                    <ns1:SimplePredicate field="col_2" operator="lessOrEqual" value="0.618381023407"/>
+                                    <ns1:ScoreDistribution confidence="0.0" recordCount="0.0" value="0"/>
+                                    <ns1:ScoreDistribution confidence="0.952380952381" recordCount="20.0" value="1"/>
+                                    <ns1:ScoreDistribution confidence="0.047619047619" recordCount="1.0" value="2"/>
+                                </ns1:Node>
+                                <ns1:Node recordCount="3.0" score="0">
+                                    <ns1:True/>
+                                    <ns1:ScoreDistribution confidence="0.4" recordCount="2.0" value="0"/>
+                                    <ns1:ScoreDistribution confidence="0.4" recordCount="2.0" value="1"/>
+                                    <ns1:ScoreDistribution confidence="0.2" recordCount="1.0" value="2"/>
+                                </ns1:Node>
+                            </ns1:Node>
+                        </ns1:Node>
+                        <ns1:Node recordCount="300.0" score="1">
+                            <ns1:True/>
+                            <ns1:ScoreDistribution confidence="0.523333333333" recordCount="157.0" value="0"/>
+                            <ns1:ScoreDistribution confidence="0.526666666667" recordCount="158.0" value="1"/>
+                            <ns1:ScoreDistribution confidence="0.496666666667" recordCount="149.0" value="2"/>
+                            <ns1:Node recordCount="39.0" score="2">
+                                <ns1:SimplePredicate field="col_0" operator="lessOrEqual" value="-0.854827046394"/>
+                                <ns1:ScoreDistribution confidence="0.487179487179" recordCount="19.0" value="0"/>
+                                <ns1:ScoreDistribution confidence="0.230769230769" recordCount="9.0" value="1"/>
+                                <ns1:ScoreDistribution confidence="0.74358974359" recordCount="29.0" value="2"/>
+                                <ns1:Node recordCount="2.0" score="1">
+                                    <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="-1.53912472725"/>
+                                    <ns1:ScoreDistribution confidence="0.0" recordCount="0.0" value="0"/>
+                                    <ns1:ScoreDistribution confidence="1.0" recordCount="2.0" value="1"/>
+                                    <ns1:ScoreDistribution confidence="0.0" recordCount="0.0" value="2"/>
+                                </ns1:Node>
+                                <ns1:Node recordCount="37.0" score="2">
+                                    <ns1:True/>
+                                    <ns1:ScoreDistribution confidence="0.345454545455" recordCount="19.0" value="0"/>
+                                    <ns1:ScoreDistribution confidence="0.127272727273" recordCount="7.0" value="1"/>
+                                    <ns1:ScoreDistribution confidence="0.527272727273" recordCount="29.0" value="2"/>
+                                </ns1:Node>
+                            </ns1:Node>
+                            <ns1:Node recordCount="261.0" score="1">
+                                <ns1:True/>
+                                <ns1:ScoreDistribution confidence="0.528735632184" recordCount="138.0" value="0"/>
+                                <ns1:ScoreDistribution confidence="0.570881226054" recordCount="149.0" value="1"/>
+                                <ns1:ScoreDistribution confidence="0.459770114943" recordCount="120.0" value="2"/>
+                                <ns1:Node recordCount="7.0" score="1">
+                                    <ns1:SimplePredicate field="col_1" operator="lessOrEqual" value="-2.00775241852"/>
+                                    <ns1:ScoreDistribution confidence="0.0" recordCount="0.0" value="0"/>
+                                    <ns1:ScoreDistribution confidence="0.9" recordCount="9.0" value="1"/>
+                                    <ns1:ScoreDistribution confidence="0.1" recordCount="1.0" value="2"/>
+                                </ns1:Node>
+                                <ns1:Node recordCount="254.0" score="1">
+                                    <ns1:True/>
+                                    <ns1:ScoreDistribution confidence="0.347607052897" recordCount="138.0" value="0"/>
+                                    <ns1:ScoreDistribution confidence="0.352644836272" recordCount="140.0" value="1"/>
+                                    <ns1:ScoreDistribution confidence="0.299748110831" recordCount="119.0" value="2"/>
+                                </ns1:Node>
+                            </ns1:Node>
+                        </ns1:Node>
+                    </ns1:Node>
+                </ns1:TreeModel>
+            </ns1:Segment>
+        </ns1:Segmentation>
+    </ns1:MiningModel>
+</ns1:PMML>

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pandas>=0.15.0
 scipy>=0.15.1
 pytest>=2.7.0
 lxml>=3.4.2
+enum34

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,8 @@ class PyTest(Command):
 
 setup(
     name='sklearn-pmml',
-    version='0.0.1',
-    packages=['sklearn_pmml', 'sklearn_pmml.convert', 'sklearn_pmml.convert.test'],
+    version='0.0.2',
+    packages=['sklearn_pmml', 'sklearn_pmml.convert'],
     install_requires=required,
     cmdclass={'test': PyTest},
     url='https://github.com/alex-pirozhenko/sklearn-pmml',

--- a/sklearn_pmml/convert/features.py
+++ b/sklearn_pmml/convert/features.py
@@ -1,23 +1,53 @@
+from enum import Enum
 import pandas as pd
 
-class Feature(object):
-    INVALID_TREATMENT_AS_IS = 'asIs'
 
-    def __init__(self, name, namespace='', invalid_value_treatment=INVALID_TREATMENT_AS_IS):
+class FeatureOpType(Enum):
+    CATEGORICAL = 'categorical'
+    CONTINUOUS = 'continuous'
+
+
+class FeatureType(Enum):
+    DOUBLE = 'double'
+    INT = 'integer'
+    STRING = 'string'
+
+
+class InvalidValueTreatment(Enum):
+    AS_IS = 'asIs'
+
+
+class Feature(object):
+    def __init__(self, name, namespace='', invalid_value_treatment=InvalidValueTreatment.AS_IS):
+        """
+        Create a new feature
+        :type name: str
+        :type namespace: str
+        :type invalid_value_treatment: InvalidValueTreatment
+        """
         self._name = name
         self._namespace = namespace
         self._invalid_value_treatment = invalid_value_treatment
 
     @property
     def name(self):
+        """
+        :rtype: str
+        """
         return self._name
 
     @property
     def namespace(self):
+        """
+        :rtype: str
+        """
         return self._namespace
 
     @property
     def full_name(self):
+        """
+        :rtype: str
+        """
         if self._namespace:
             return '{}::{}'.format(self._namespace, self.name)
         else:
@@ -29,10 +59,16 @@ class Feature(object):
 
     @property
     def optype(self):
+        """
+        :rtype: FeatureOpType
+        """
         raise NotImplementedError()
 
     @property
     def data_type(self):
+        """
+        :rtype: FeatureType
+        """
         raise NotImplementedError()
 
     def from_number(self, value):
@@ -48,7 +84,7 @@ class Feature(object):
 class NumericFeature(Feature):
     @property
     def optype(self):
-        return "continuous"
+        return FeatureOpType.CONTINUOUS
 
     def from_number(self, value):
         return float(value)
@@ -57,7 +93,7 @@ class NumericFeature(Feature):
 class RealNumericFeature(NumericFeature):
     @property
     def data_type(self):
-        return "double"
+        return FeatureType.DOUBLE
 
 
 class IntegerNumericFeature(NumericFeature):
@@ -66,7 +102,7 @@ class IntegerNumericFeature(NumericFeature):
 
     @property
     def data_type(self):
-        return "integer"
+        return FeatureType.INT
 
 
 class CategoricalFeature(Feature):
@@ -75,13 +111,13 @@ class CategoricalFeature(Feature):
     dataType. The corresponding derived field will have a double data type and will be defined as a MapValues PMML
     element.
     """
-    def __init__(self, name, value_list, namespace='', invalid_value_treatment=Feature.INVALID_TREATMENT_AS_IS):
+    def __init__(self, name, value_list, namespace='', invalid_value_treatment=InvalidValueTreatment.AS_IS):
         super(CategoricalFeature, self).__init__(name, namespace, invalid_value_treatment)
         self.value_list = value_list
 
     @property
     def optype(self):
-        return "categorical"
+        return FeatureOpType.CATEGORICAL
 
     def from_number(self, value):
         assert value >= 0, 'Negative numbers can not be used as categorical indexes'
@@ -92,13 +128,13 @@ class CategoricalFeature(Feature):
 class IntegerCategoricalFeature(CategoricalFeature):
     @property
     def data_type(self):
-        return "integer"
+        return FeatureType.INT
 
 
 class StringCategoricalFeature(CategoricalFeature):
     @property
     def data_type(self):
-        return "string"
+        return FeatureType.STRING
 
 
 class DerivedFeature(NumericFeature):
@@ -127,7 +163,6 @@ class DerivedFeature(NumericFeature):
         self.feature = feature
         self.transformation = transformation
         self.function = function
-
 
     def from_number(self, value):
         return self.feature.from_number(value)

--- a/sklearn_pmml/convert/features.py
+++ b/sklearn_pmml/convert/features.py
@@ -25,8 +25,8 @@ class Feature(object):
         :type namespace: str
         :type invalid_value_treatment: InvalidValueTreatment
         """
-        self._name = name
-        self._namespace = namespace
+        self._name = str(name)
+        self._namespace = str(namespace)
         self._invalid_value_treatment = invalid_value_treatment
 
     @property

--- a/sklearn_pmml/convert/gbrt.py
+++ b/sklearn_pmml/convert/gbrt.py
@@ -1,7 +1,9 @@
+from copy import copy
 from sklearn.ensemble import GradientBoostingClassifier
 
 from sklearn.ensemble.gradient_boosting import LogOddsEstimator
 
+from sklearn_pmml.convert.features import *
 from sklearn_pmml.convert.model import EstimatorConverter
 from sklearn_pmml.convert.tree import DecisionTreeConverter
 import sklearn_pmml.pmml as pmml
@@ -33,8 +35,8 @@ class GradientBoostingConverter(EstimatorConverter):
             'This converter can only process GradientBoostingClassifier instances'
         assert len(context.schemas[self.SCHEMA_OUTPUT]) == 1, 'Only one-label classification is supported'
         assert not estimator.loss_.is_multi_class, 'Only one-label classification is supported'
-        assert context.schemas[self.SCHEMA_OUTPUT][0].data_type == 'double', 'PMML version only returns probabilities'
-        assert context.schemas[self.SCHEMA_OUTPUT][0].optype == 'continuous', 'PMML version only returns probabilities'
+        # assert context.schemas[self.SCHEMA_OUTPUT][0].data_type == 'double', 'PMML version only returns probabilities'
+        assert context.schemas[self.SCHEMA_OUTPUT][0].optype == 'categorical', 'Classification output must be categorical'
         assert find_converter(estimator.init_) is not None, 'Can not find a converter for {}'.format(estimator.init_)
 
     def model(self, verification_data=None):
@@ -56,29 +58,32 @@ class GradientBoostingConverter(EstimatorConverter):
         output = pmml.Output()
         output.append(pmml.OutputField(feature='predictedValue', name='predictedValue'))
         output_feature = self.context.schemas[self.SCHEMA_OUTPUT][0]
-        output_field = pmml.OutputField(
-            dataType='double', feature='transformedValue',
-            name=output_feature.full_name, optype=output_feature.optype
-        )
-        neg = pmml.Apply(function='*')
-        neg.append(pmml.FieldRef(field='predictedValue'))
-        neg.append(pmml.Constant(
-            # there is no notion of weighted sum in segment aggregation, so we used weighted average,
-            # and now the result should be multiplied by total weight
-            -(1 + self.estimator.n_estimators * self.estimator.learning_rate),
-            dataType='double'
-        ))
-        exp = pmml.Apply(function='exp')
-        exp.append(neg)
-        plus = pmml.Apply(function='+')
-        plus.append(pmml.Constant(1.0, dataType='double'))
-        plus.append(exp)
-        div = pmml.Apply(function='/')
-        div.append(pmml.Constant(1.0, dataType='double'))
-        div.append(plus)
+        if isinstance(output_feature, CategoricalFeature):
+            for output_value in output_feature.value_list:
+                output_field = pmml.OutputField(
+                    dataType='double', feature='transformedValue',
+                    name='output::' + output_feature.full_name + '::' + str(output_value),
+                    optype=output_feature.optype
+                )
+                neg = pmml.Apply(function='*')
+                neg.append(pmml.FieldRef(field='predictedValue'))
+                neg.append(pmml.Constant(
+                    # there is no notion of weighted sum in segment aggregation, so we used weighted average,
+                    # and now the result should be multiplied by total weight
+                    -(1 + self.estimator.n_estimators * self.estimator.learning_rate),
+                    dataType='double'
+                ))
+                exp = pmml.Apply(function='exp')
+                exp.append(neg)
+                plus = pmml.Apply(function='+')
+                plus.append(pmml.Constant(1.0, dataType='double'))
+                plus.append(exp)
+                div = pmml.Apply(function='/')
+                div.append(pmml.Constant(1.0, dataType='double'))
+                div.append(plus)
+                output_field.append(div)
+                output.append(output_field)
 
-        output_field.append(div)
-        output.append(output_field)
         return output
 
     def segmentation(self):
@@ -90,16 +95,23 @@ class GradientBoostingConverter(EstimatorConverter):
         # in output transformation
         segmentation = pmml.Segmentation(multipleModelMethod="weightedAverage")
 
+        # build the context for the nested regression models by replacing output categorical feature with the continuous numeric feature
+        regression_context = copy(self.context)
+        regression_context.schemas[self.SCHEMA_OUTPUT] = [RealNumericFeature(
+            name=self.context.schemas[self.SCHEMA_OUTPUT][0].name,
+            namespace=self.SCHEMA_NUMERIC
+        )]
+
         # first, transform initial estimator
         init_segment = pmml.Segment(weight=1)
         init_segment.append(pmml.True_())
-        init_segment.append(find_converter(self.estimator.init_)(self.estimator.init_, self.context).model())
+        init_segment.append(find_converter(self.estimator.init_)(self.estimator.init_, regression_context).model())
         segmentation.append(init_segment)
 
         for est in self.estimator.estimators_[:, 0]:
             s = pmml.Segment(weight=self.estimator.learning_rate)
             s.append(pmml.True_())
-            s.append(DecisionTreeConverter(est, self.context, self.MODE_REGRESSION)._model())
+            s.append(DecisionTreeConverter(est, regression_context, self.MODE_REGRESSION)._model())
             segmentation.append(s)
 
         return segmentation

--- a/sklearn_pmml/convert/model.py
+++ b/sklearn_pmml/convert/model.py
@@ -146,7 +146,7 @@ class EstimatorConverter(object):
         except the ones defined as Derived Features
         """
         dd = pmml.DataDictionary()
-        for schema, fields in self.context.schemas.items():
+        for schema, fields in sorted(self.context.schemas.items(), key=lambda x: x[0].name):
             assert isinstance(schema, Schema)
             if schema.eligible_for_data_dictionary:
                 for f in fields:

--- a/sklearn_pmml/convert/model.py
+++ b/sklearn_pmml/convert/model.py
@@ -66,20 +66,19 @@ class EstimatorConverter(object):
 
     def output(self):
         output = pmml.Output()
-        output_field = pmml.OutputField(name=self.context.schemas[self.SCHEMA_OUTPUT][0], feature='predictedValue')
-        output.append(output_field)
-        for output_variable in self.context.schemas[self.SCHEMA_OUTPUT]:
-            if isinstance(output_variable, CategoricalFeature):
-                for output_value in output_variable.value_list:
-                    output_field = pmml.OutputField(name='Probability_' + str(output_value),
+        for output_label in self.context.schemas[self.SCHEMA_OUTPUT]:
+            output_field = pmml.OutputField(name='output::' + str(output_label), feature='predictedValue')
+            output.append(output_field)
+            if isinstance(output_label, CategoricalFeature):
+                for output_value in output_label.value_list:
+                    output_field = pmml.OutputField(name='output::' + str(output_label) + '::' + str(output_value),
                                                     optype='continuous',
                                                     dataType='double',
                                                     feature='probability',
-                                                    targetField=str(output_variable),
+                                                    targetField=str(output_label),
                                                     value_=str(output_value))
                     output.append(output_field)
         return output
-
 
     def transformation_dictionary(self):
         """

--- a/sklearn_pmml/convert/random_forest.py
+++ b/sklearn_pmml/convert/random_forest.py
@@ -2,21 +2,22 @@ __author__ = 'evancox'
 
 
 from sklearn.ensemble import RandomForestClassifier
-from sklearn_pmml.convert.model import EstimatorConverter
+from sklearn_pmml.convert.model import EstimatorConverter, Schema, ModelMode
 from sklearn_pmml.convert.tree import DecisionTreeConverter
 from sklearn_pmml.convert.utils import estimator_to_converter
 
 import sklearn_pmml.pmml as pmml
 
+
 class RandomForestClassifierConverter(EstimatorConverter):
     def __init__(self, estimator, context):
-        super(RandomForestClassifierConverter, self).__init__(estimator, context, self.MODE_CLASSIFICATION)
+        super(RandomForestClassifierConverter, self).__init__(estimator, context, ModelMode.CLASSIFICATION)
         assert isinstance(estimator, RandomForestClassifier), \
             'This converter can only process RandomForestClassifier instances'
-        assert len(context.schemas[self.SCHEMA_OUTPUT]) == 1, 'Only one-label classification is supported'
+        assert len(context.schemas[Schema.OUTPUT]) == 1, 'Only one-label classification is supported'
 
     def model(self, verification_data=None):
-        mining_model = pmml.MiningModel(functionName=self.MODE_CLASSIFICATION)
+        mining_model = pmml.MiningModel(functionName=ModelMode.CLASSIFICATION.value)
         mining_model.append(self.mining_schema())
         mining_model.append(self.output())
         mining_model.append(self.segmentation())
@@ -35,7 +36,7 @@ class RandomForestClassifierConverter(EstimatorConverter):
         for index, est in enumerate(self.estimator.estimators_):
             s = pmml.Segment(id=index)
             s.append(pmml.True_())
-            s.append(DecisionTreeConverter(est, self.context, self.MODE_CLASSIFICATION)._model())
+            s.append(DecisionTreeConverter(est, self.context, ModelMode.CLASSIFICATION)._model())
             segmentation.append(s)
 
         return segmentation

--- a/sklearn_pmml/convert/random_forest.py
+++ b/sklearn_pmml/convert/random_forest.py
@@ -30,7 +30,7 @@ class RandomForestClassifierConverter(EstimatorConverter):
         Build a segmentation (sequence of estimators)
         :return: Segmentation element
         """
-        segmentation = pmml.Segmentation(multipleModelMethod="majorityVote")
+        segmentation = pmml.Segmentation(multipleModelMethod="weightedAverage")
 
         for index, est in enumerate(self.estimator.estimators_):
             s = pmml.Segment(id=index)

--- a/sklearn_pmml/convert/random_forest.py
+++ b/sklearn_pmml/convert/random_forest.py
@@ -1,17 +1,19 @@
+from sklearn_pmml.convert import CategoricalFeature
+
 __author__ = 'evancox'
 
 
 from sklearn.ensemble import RandomForestClassifier
-from sklearn_pmml.convert.model import EstimatorConverter, Schema, ModelMode
+from sklearn_pmml.convert.model import Schema, ModelMode, ClassifierConverter
 from sklearn_pmml.convert.tree import DecisionTreeConverter
 from sklearn_pmml.convert.utils import estimator_to_converter
 
 import sklearn_pmml.pmml as pmml
 
 
-class RandomForestClassifierConverter(EstimatorConverter):
+class RandomForestClassifierConverter(ClassifierConverter):
     def __init__(self, estimator, context):
-        super(RandomForestClassifierConverter, self).__init__(estimator, context, ModelMode.CLASSIFICATION)
+        super(RandomForestClassifierConverter, self).__init__(estimator, context)
         assert isinstance(estimator, RandomForestClassifier), \
             'This converter can only process RandomForestClassifier instances'
         assert len(context.schemas[Schema.OUTPUT]) == 1, 'Only one-label classification is supported'
@@ -24,7 +26,6 @@ class RandomForestClassifierConverter(EstimatorConverter):
         if verification_data is not None:
             mining_model.append(self.model_verification(verification_data))
         return mining_model
-
 
     def segmentation(self):
         """

--- a/sklearn_pmml/convert/test/jpmml-csv-evaluator/README.md
+++ b/sklearn_pmml/convert/test/jpmml-csv-evaluator/README.md
@@ -1,0 +1,19 @@
+# About
+This is a simple [JPMML](http://github.com/jpmml)-based CLI evaluator for PMML models.
+
+# Notes
+This submodule relies on AGPL library [jpmml-evaluator](http://github.com/jpmml/jpmml-evaluator), 
+but it's only used for testing and it's not a part of sklearn-pmml distribution.
+Since users will not interact with AGPL-licensed library, I think it's OK to use it in tests.
+ 
+# Usage
+1. Build the JAR file (make sure you have JDK8 installed):
+```
+mvn clean package
+```
+2. Run with maven:
+```
+mvn exec:java -e -q \
+-Dexec.mainClass=sklearn.pmml.jpmml.JPMMLCSVEvaluator \
+-Dexec.args=/path/to/pmml /path/to/input.csv /path/to/output.csv 
+```

--- a/sklearn_pmml/convert/test/jpmml-csv-evaluator/pom.xml
+++ b/sklearn_pmml/convert/test/jpmml-csv-evaluator/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -42,8 +42,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.0</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/sklearn_pmml/convert/test/jpmml-csv-evaluator/pom.xml
+++ b/sklearn_pmml/convert/test/jpmml-csv-evaluator/pom.xml
@@ -14,14 +14,14 @@
             <groupId>org.jpmml</groupId>
             <artifactId>pmml-evaluator</artifactId>
             <!-- DO NOT UPGRADE: newer versions are licensed under AGPL -->
-            <version>1.0.22</version>
+            <version>1.2.5</version>
         </dependency>
 
         <dependency>
             <groupId>org.jpmml</groupId>
             <artifactId>pmml-model</artifactId>
             <!-- OK to upgrade this one: released under BSD 3-clause. Must not upgrade pmml-evaluator.  -->
-            <version>1.0.22</version>
+            <version>1.2.6</version>
         </dependency>
 
         <dependency>

--- a/sklearn_pmml/convert/test/jpmml-csv-evaluator/src/main/java/sklearn/pmml/jpmml/JPMMLCSVEvaluator.java
+++ b/sklearn_pmml/convert/test/jpmml-csv-evaluator/src/main/java/sklearn/pmml/jpmml/JPMMLCSVEvaluator.java
@@ -97,11 +97,11 @@ public class JPMMLCSVEvaluator
 
     static void writePredictions(Evaluator evaluator, List<Map<FieldName, ?>> predictions, String outputFile) throws IOException
     {
-        final int outputFieldCount = evaluator.getOutputFields().size();
+        final int outputFieldCount = predictions.get(0).keySet().size();
         final Set<FieldName> outputFields = Sets.newHashSetWithExpectedSize(outputFieldCount);
         final String[] header = new String[outputFieldCount];
         int index = 0;
-        for (FieldName fieldName : evaluator.getOutputFields())
+        for (FieldName fieldName : predictions.get(0).keySet())
         {
             outputFields.add(fieldName);
             header[index++] = fieldName.toString();

--- a/sklearn_pmml/convert/test/jpmml-csv-evaluator/src/main/java/sklearn/pmml/jpmml/JPMMLCSVEvaluator.java
+++ b/sklearn_pmml/convert/test/jpmml-csv-evaluator/src/main/java/sklearn/pmml/jpmml/JPMMLCSVEvaluator.java
@@ -103,8 +103,10 @@ public class JPMMLCSVEvaluator
         int index = 0;
         for (FieldName fieldName : predictions.get(0).keySet())
         {
-            outputFields.add(fieldName);
-            header[index++] = fieldName.toString();
+            if (fieldName != null) {
+                outputFields.add(fieldName);
+                header[index++] = fieldName.toString();
+            }
         }
 
         try (final CsvMapWriter csvMapWriter = new CsvMapWriter(new FileWriter(outputFile), CsvPreference.STANDARD_PREFERENCE))
@@ -115,7 +117,9 @@ public class JPMMLCSVEvaluator
                 final Map<String, Object> row = Maps.newHashMapWithExpectedSize(prediction.size());
                 for (Map.Entry<FieldName, ?> keyValue : prediction.entrySet())
                 {
-                    row.put(keyValue.getKey().toString(), keyValue.getValue());
+                    if (keyValue.getKey() != null) {
+                        row.put(keyValue.getKey().toString(), keyValue.getValue());
+                    }
                 }
                 csvMapWriter.write(row, header);
             }
@@ -134,7 +138,7 @@ public class JPMMLCSVEvaluator
         try
         {
             Evaluator evaluator = evaluatorFromXml(new FileInputStream(pmmlFile));
-//            evaluator.verify();
+            evaluator.verify();
             final List<Map<FieldName, ?>> predictions = getPredictions(evaluator, csvFeaturesFile);
             writePredictions(evaluator, predictions, outputFile);
             logger.info(String.format("Wrote %d predictions from %s to %s", predictions.size(), csvFeaturesFile, outputFile));

--- a/sklearn_pmml/convert/test/jpmml_test.py
+++ b/sklearn_pmml/convert/test/jpmml_test.py
@@ -120,7 +120,7 @@ class JPMMLTest():
             os.path.abspath(target_file_path)
         ]))
         result = subprocess.call([
-            'mvn', 'exec:java', '-q', '-e',
+            'mvn', 'package' 'exec:java', '-q', '-e',
             '-f', find_file_or_dir('jpmml-csv-evaluator'),
             '-Dexec.mainClass=sklearn.pmml.jpmml.JPMMLCSVEvaluator',
             '-Dexec.args=' + java_args

--- a/sklearn_pmml/convert/test/jpmml_test.py
+++ b/sklearn_pmml/convert/test/jpmml_test.py
@@ -7,18 +7,20 @@ import shutil
 import subprocess
 import logging
 
-
-from sklearn_pmml.convert import TransformationContext
+from sklearn_pmml.convert import TransformationContext, Schema
 from sklearn_pmml.convert.features import *
 
 
-_TARGET = [0, 1, 2]
-_TARGET_NAME = 'y'
-_TEST_DIR = 'jpmml_test_data'
+TARGET = [0, 1, 2]
+TARGET_NAME = 'y'
+TEST_DIR = 'jpmml_test_data'
+
+EPSILON = 0.00001
 
 logging.basicConfig(format='%(asctime)s %(message)s')
 
-#Adapted from http://stackoverflow.com/questions/1724693/find-a-file-in-python
+
+# Adapted from http://stackoverflow.com/questions/1724693/find-a-file-in-python
 def find_file_or_dir(name):
     for root, dirs, files in os.walk(os.path.dirname(__file__)):
         if name in files or name in dirs:
@@ -26,10 +28,17 @@ def find_file_or_dir(name):
 
 
 class JPMMLTest():
+    USE_VERIFICATION = False
+    """
+    If true, the PMML will be generated with the ModelVerification section that allows PMML interpreter to check the
+    correctness of deserialized model.
+    """
 
     def __init__(self):
         self.x = None
         self.y = None
+        self.ctx = None
+        self.converter = None
 
     @staticmethod
     def can_run():
@@ -42,12 +51,10 @@ class JPMMLTest():
         try:
             subprocess.check_call(['mvn', '-version'])
         except OSError:
-            logging.warning("Couldn't find java to run JPMML integration tests")
+            logging.warning("Couldn't find maven to run JPMML integration tests")
             return False
 
         return True
-
-
 
     @staticmethod
     def init_jpmml():
@@ -55,7 +62,7 @@ class JPMMLTest():
         assert result == 0, "Unable to package jpmml csv evaluator"
         return True
 
-    #taken from http://stackoverflow.com/questions/18159221/remove-namespace-and-prefix-from-xml-in-python-using-lxml
+    # taken from http://stackoverflow.com/questions/18159221/remove-namespace-and-prefix-from-xml-in-python-using-lxml
     @staticmethod
     def remove_namespace(doc, namespace):
         ns = u'{%s}' % namespace
@@ -83,91 +90,88 @@ class JPMMLTest():
             logging.warning("Can't run regression test, java and/or maven not installed")
             return None
 
-        if os.path.exists(_TEST_DIR):
-            shutil.rmtree(_TEST_DIR)
-        os.makedirs(_TEST_DIR)
+        if os.path.exists(TEST_DIR):
+            shutil.rmtree(TEST_DIR)
+        os.makedirs(TEST_DIR)
 
-        #evancox This is a hack to allow us to mark the version down as 4.1 so we can run with the BSD version of JPMML rather than the AGPL one
-        verification_data = self.x.copy()
-        verification_data[_TARGET_NAME] = self._model.predict_proba(self.x.values)[:, 1]
-        # xml = self.converter.pmml(verification_data=[
-        #     dict((str(_[0]), _[1]) for _ in dict(row).items())
-        #     for idx, row in verification_data[:10].iterrows()
-        # ]).toxml("utf-8")
+        if self.USE_VERIFICATION:
+            verification_data = self.x.copy()
+            verification_data[TARGET_NAME] = self._model.predict_proba(self.x.values)[:, 1]
 
-
-        xml = self.converter.pmml().toxml("utf-8")
-
-        # pmml = etree.fromstring(xml)
-        # pmml.set('version', '4.1')
-        # JPMMLTest.remove_namespace(pmml, 'http://www.dmg.org/PMML-4_2')
-        # xml = etree.tostring(pmml, pretty_print=True)
-        # xml = xml.replace('http://www.dmg.org/PMML-4_2', 'http://www.dmg.org/PMML-4_1')
+            xml = self.converter.pmml(verification_data=[
+                dict((str(_[0]), _[1]) for _ in dict(row).items())
+                for idx, row in verification_data[:10].iterrows()
+            ]).toDOM().toprettyxml()
+        else:
+            xml = self.converter.pmml().toDOM().toprettyxml()
 
         pmml_hash = hashlib.md5(xml).hexdigest()
-        pmml_file_path = os.path.join(_TEST_DIR, pmml_hash + '.pmml')
+        pmml_file_path = os.path.join(TEST_DIR, pmml_hash + '.pmml')
         with open(pmml_file_path, 'w') as pmml_file:
             pmml_file.write(xml)
 
-        input_file_path = os.path.join(_TEST_DIR, pmml_hash + '_input.csv')
-        self.x.to_csv(input_file_path,index=False)
-        target_file_path = os.path.join(_TEST_DIR, pmml_hash + '_output.csv')
+        input_file_path = os.path.join(TEST_DIR, pmml_hash + '_input.csv')
+        self.x.to_csv(input_file_path, index=False)
+        target_file_path = os.path.join(TEST_DIR, pmml_hash + '_output.csv')
 
-        java_args = ' '.join([os.path.abspath(pmml_file_path), os.path.abspath(input_file_path), os.path.abspath(target_file_path)])
-        result = subprocess.call(['mvn', 'exec:java', '-q', '-f', find_file_or_dir('jpmml-csv-evaluator'), '-Dexec.mainClass=sklearn.pmml.jpmml.JPMMLCSVEvaluator', '-Dexec.args=' + java_args, '-e'])
-        self.assertEqual(result, 0, 'Executing jpmml evaluator returned non zero result')
+        java_args = ' '.join(map("'{}'".format, [
+            os.path.abspath(pmml_file_path),
+            os.path.abspath(input_file_path),
+            os.path.abspath(target_file_path)
+        ]))
+        result = subprocess.call([
+            'mvn', 'exec:java', '-q', '-e',
+            '-f', find_file_or_dir('jpmml-csv-evaluator'),
+            '-Dexec.mainClass=sklearn.pmml.jpmml.JPMMLCSVEvaluator',
+            '-Dexec.args=' + java_args
+        ])
+        if result:
+            print(xml)
+        assert result == 0, 'Executing JPMML evaluator returned non zero result'
         return pd.read_csv(target_file_path)
 
     def init_data(self):
         np.random.seed(12363)
-        self.x = pd.DataFrame(np.random.randn(500, 4))
-        self.y = pd.DataFrame({_TARGET_NAME:[np.random.choice([0, 1, 2]) for _ in range(self.x.shape[0])]})
+        self.x = pd.DataFrame(np.random.randn(500, 4), columns=['col_' + str(_) for _ in range(4)])
+        self.y = pd.DataFrame({TARGET_NAME: [np.random.choice([0, 1, 2]) for _ in range(self.x.shape[0])]})
         self._model.fit(self.x, np.ravel(self.y))
-        self.ctx = TransformationContext(
-            input=[RealNumericFeature(col) for col in list(self.x)],
-            derived=[],
-            model=[RealNumericFeature(col) for col in list(self.x)],
-            output=[self.output]
-        )
+        self.ctx = TransformationContext()
+        self.ctx.schemas[Schema.INPUT] = [RealNumericFeature(col) for col in list(self.x)]
+        self.ctx.schemas[Schema.DERIVED] = []
+        self.ctx.schemas[Schema.MODEL] = [RealNumericFeature(col) for col in list(self.x)]
+        self.ctx.schemas[Schema.OUTPUT] = [self.output]
 
     def init_data_one_label(self):
         np.random.seed(12363)
-        self.x = pd.DataFrame(np.random.randn(500, 4), columns=['col_'+str(_) for _ in range(4)])
-        self.y = pd.DataFrame({_TARGET_NAME:[np.random.choice([0, 1]) for _ in range(self.x.shape[0])]})
+        self.x = pd.DataFrame(np.random.randn(500, 4), columns=['col_' + str(_) for _ in range(4)])
+        self.y = pd.DataFrame({TARGET_NAME: [np.random.choice([0, 1]) for _ in range(self.x.shape[0])]})
         self._model.fit(self.x, np.ravel(self.y))
-        self.ctx = TransformationContext(
-            input=[RealNumericFeature(col) for col in self.x.columns],
-            derived=[],
-            model=[RealNumericFeature(col) for col in self.x.columns],
-            output=[self.output]
-        )
-
-
-
-
+        self.ctx = TransformationContext()
+        self.ctx.schemas[Schema.INPUT] = [RealNumericFeature(col) for col in list(self.x)]
+        self.ctx.schemas[Schema.DERIVED] = []
+        self.ctx.schemas[Schema.MODEL] = [RealNumericFeature(col) for col in list(self.x)]
+        self.ctx.schemas[Schema.OUTPUT] = [self.output]
 
 
 class JPMMLRegressionTest(JPMMLTest):
-
     @property
     def output(self):
-        return IntegerNumericFeature(_TARGET_NAME, _TARGET)
+        return IntegerNumericFeature(name=TARGET_NAME)
 
     def test_regression(self):
         jpmml_predictions = self.setup_jpmml_test()
         if jpmml_predictions is None:
             return
 
-        sklearn_predictions = pd.DataFrame({_TARGET_NAME:self.converter.estimator.predict(self.x)})
-        diff = jpmml_predictions[_TARGET_NAME] - sklearn_predictions[_TARGET_NAME]
-        self.assertTrue(np.all(np.abs(diff) < .001))
+        sklearn_predictions = pd.DataFrame({TARGET_NAME: self.converter.estimator.predict(self.x)})
+        diff = jpmml_predictions[TARGET_NAME] - sklearn_predictions[TARGET_NAME]
+        assert np.all(np.abs(diff) < EPSILON)
 
 
 class JPMMLClassificationTest(JPMMLTest):
-
     @property
     def output(self):
-        return StringCategoricalFeature(_TARGET_NAME, _TARGET)
+        return StringCategoricalFeature(name=TARGET_NAME, value_list=["negative", "positive"])
 
     def test_classification(self):
 
@@ -176,12 +180,12 @@ class JPMMLClassificationTest(JPMMLTest):
             return
 
         raw_sklearn_predictions = self.converter.estimator.predict_proba(self.x)
-        prob_outputs = ['output::' + str(self.output) + '::' + str(clazz) for clazz in self.converter.estimator.classes_]
+        prob_outputs = [str(self.output) + '::' + str(clazz) for clazz in
+                        self.converter.estimator.classes_]
         sklearn_predictions = pd.DataFrame(columns=prob_outputs)
         for index, prediction in enumerate(raw_sklearn_predictions):
             sklearn_predictions.loc[index] = list(prediction)
-        self.assertTrue(not np.testing.assert_almost_equal(
+        assert not np.testing.assert_almost_equal(
             np.array(jpmml_predictions[list(sklearn_predictions.columns)]),
-            sklearn_predictions))
-
-
+            sklearn_predictions
+        )

--- a/sklearn_pmml/convert/test/jpmml_test.py
+++ b/sklearn_pmml/convert/test/jpmml_test.py
@@ -180,8 +180,7 @@ class JPMMLClassificationTest(JPMMLTest):
             return
 
         raw_sklearn_predictions = self.converter.estimator.predict_proba(self.x)
-        prob_outputs = [str(self.output) + '::' + str(clazz) for clazz in
-                        self.converter.estimator.classes_]
+        prob_outputs = [str(self.output) + '::' + str(clazz) for clazz in self.output.value_list]
         sklearn_predictions = pd.DataFrame(columns=prob_outputs)
         for index, prediction in enumerate(raw_sklearn_predictions):
             sklearn_predictions.loc[index] = list(prediction)

--- a/sklearn_pmml/convert/test/jpmml_test.py
+++ b/sklearn_pmml/convert/test/jpmml_test.py
@@ -105,7 +105,7 @@ class JPMMLTest():
         else:
             xml = self.converter.pmml().toDOM().toprettyxml()
 
-        pmml_hash = hashlib.md5(xml).hexdigest()
+        pmml_hash = hashlib.md5(xml.encode('utf-8')).hexdigest()
         pmml_file_path = os.path.join(TEST_DIR, pmml_hash + '.pmml')
         with open(pmml_file_path, 'w') as pmml_file:
             pmml_file.write(xml)

--- a/sklearn_pmml/convert/test/jpmml_test.py
+++ b/sklearn_pmml/convert/test/jpmml_test.py
@@ -180,11 +180,18 @@ class JPMMLClassificationTest(JPMMLTest):
             return
 
         raw_sklearn_predictions = self.converter.estimator.predict_proba(self.x)
-        prob_outputs = [str(self.output) + '::' + str(clazz) for clazz in self.output.value_list]
+        prob_outputs = [self.output.name + '::' + str(clazz) for clazz in self.output.value_list]
         sklearn_predictions = pd.DataFrame(columns=prob_outputs)
         for index, prediction in enumerate(raw_sklearn_predictions):
             sklearn_predictions.loc[index] = list(prediction)
-        assert not np.testing.assert_almost_equal(
+
+        np.testing.assert_almost_equal(
             np.array(jpmml_predictions[list(sklearn_predictions.columns)]),
-            sklearn_predictions
+            sklearn_predictions.values,
+            err_msg='Probability mismatch'
+        )
+        np.testing.assert_equal(
+            np.array(self.output.value_list)[self.converter.estimator.predict(self.x)],
+            jpmml_predictions[self.output.name].values,
+            err_msg='Labels mismatch'
         )

--- a/sklearn_pmml/convert/test/jpmml_test.py
+++ b/sklearn_pmml/convert/test/jpmml_test.py
@@ -120,7 +120,7 @@ class JPMMLTest():
             os.path.abspath(target_file_path)
         ]))
         result = subprocess.call([
-            'mvn', 'package' 'exec:java', '-q', '-e',
+            'mvn', 'package', 'exec:java', '-q', '-e',
             '-f', find_file_or_dir('jpmml-csv-evaluator'),
             '-Dexec.mainClass=sklearn.pmml.jpmml.JPMMLCSVEvaluator',
             '-Dexec.args=' + java_args

--- a/sklearn_pmml/convert/test/test_decisionTreeClassifierConverter.py
+++ b/sklearn_pmml/convert/test/test_decisionTreeClassifierConverter.py
@@ -1,5 +1,5 @@
 import numpy as np
-from jpmml_test import JPMMLClassificationTest, JPMMLRegressionTest, TARGET_NAME, TARGET
+from sklearn_pmml.convert.test.jpmml_test import JPMMLClassificationTest, JPMMLRegressionTest, TARGET_NAME, TARGET
 
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 

--- a/sklearn_pmml/convert/test/test_derived_fields.py
+++ b/sklearn_pmml/convert/test/test_derived_fields.py
@@ -1,6 +1,7 @@
 import pytest
 from sklearn.tree import DecisionTreeClassifier
 from sklearn_pmml import EstimatorConverter, TransformationContext, pmml
+from sklearn_pmml.convert import Schema, ModelMode
 from sklearn_pmml.convert.features import *
 
 test_cases = [
@@ -35,13 +36,13 @@ test_cases = [
 def test_transformation_dictionary(input_fields, derived_fields, output_fields, expected_data_dictionary, expected_transformation_dictionary):
     converter = EstimatorConverter(
         DecisionTreeClassifier(),
-        context=TransformationContext(
-            input=input_fields,
-            derived=derived_fields,
-            model=input_fields+derived_fields,
-            output=output_fields
-        ),
-        mode=EstimatorConverter.MODE_CLASSIFICATION
+        context=TransformationContext({
+            Schema.INPUT: input_fields,
+            Schema.DERIVED: derived_fields,
+            Schema.MODEL: input_fields + derived_fields,
+            Schema.OUTPUT: output_fields
+        }),
+        mode=ModelMode.CLASSIFICATION
     )
 
     assert converter.data_dictionary().toxml() == expected_data_dictionary, 'Error in data dictionary generation'

--- a/sklearn_pmml/convert/test/test_gradientBoostingConverter.py
+++ b/sklearn_pmml/convert/test/test_gradientBoostingConverter.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 from sklearn.ensemble import GradientBoostingClassifier
 import numpy as np
 
+from sklearn_pmml.convert.test.jpmml_test import JPMMLClassificationTest, JPMMLTest, _TARGET_NAME
 from sklearn_pmml.convert import TransformationContext
 from sklearn_pmml.convert.features import *
 from sklearn_pmml.convert.gbrt import GradientBoostingConverter
@@ -48,3 +49,18 @@ class TestGradientBoostingClassifierConverter(TestCase):
         assert len(mm.MiningSchema.MiningField) == 3, 'Wrong number of mining fields'
         assert mm.Segmentation is not None, 'Missing segmentation root'
 
+
+class TestGradientBoostingClassifierParity(TestCase, JPMMLClassificationTest):
+
+    @classmethod
+    def setUpClass(cls):
+        if JPMMLTest.can_run():
+            JPMMLTest.init_jpmml()
+
+    def setUp(self):
+        self.model = GradientBoostingClassifier(n_estimators=2)
+        self.init_data_one_label()
+        self.converter = GradientBoostingConverter(
+            estimator=self.model,
+            context=self.ctx
+        )

--- a/sklearn_pmml/convert/test/test_gradientBoostingConverter.py
+++ b/sklearn_pmml/convert/test/test_gradientBoostingConverter.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 from sklearn.ensemble import GradientBoostingClassifier
 import numpy as np
 
-from sklearn_pmml.convert.test.jpmml_test import JPMMLClassificationTest, JPMMLTest, _TARGET_NAME
+from sklearn_pmml.convert.test.jpmml_test import JPMMLClassificationTest, JPMMLTest, TARGET_NAME
 from sklearn_pmml.convert import TransformationContext
 from sklearn_pmml.convert.features import *
 from sklearn_pmml.convert.gbrt import GradientBoostingConverter

--- a/sklearn_pmml/convert/test/test_gradientBoostingConverter.py
+++ b/sklearn_pmml/convert/test/test_gradientBoostingConverter.py
@@ -4,7 +4,7 @@ from sklearn.ensemble import GradientBoostingClassifier
 import numpy as np
 
 from sklearn_pmml.convert.test.jpmml_test import JPMMLClassificationTest, JPMMLTest, TARGET_NAME
-from sklearn_pmml.convert import TransformationContext
+from sklearn_pmml.convert import TransformationContext, Schema
 from sklearn_pmml.convert.features import *
 from sklearn_pmml.convert.gbrt import GradientBoostingConverter
 
@@ -19,12 +19,20 @@ class TestGradientBoostingClassifierConverter(TestCase):
             [1, 0],
             [1, 1],
         ], [0, 1, 1, 1])
-        self.ctx = TransformationContext(
-            input=[IntegerNumericFeature('x1'), StringCategoricalFeature('x2', ['zero', 'one'])],
-            derived=[],
-            model=[IntegerNumericFeature('x1'), StringCategoricalFeature('x2', ['zero', 'one'])],
-            output=[RealNumericFeature('output')]
-        )
+        self.ctx = TransformationContext({
+            Schema.INPUT: [
+                IntegerNumericFeature('x1'),
+                StringCategoricalFeature('x2', ['zero', 'one'])
+            ],
+            Schema.MODEL: [
+                IntegerNumericFeature('x1'),
+                StringCategoricalFeature('x2', ['zero', 'one'])
+            ],
+            Schema.DERIVED: [],
+            Schema.OUTPUT: [
+                IntegerCategoricalFeature('output', [0, 1])
+            ]
+        })
         self.converter = GradientBoostingConverter(
             estimator=self.est,
             context=self.ctx
@@ -34,7 +42,7 @@ class TestGradientBoostingClassifierConverter(TestCase):
         p = self.converter.pmml()
         mm = p.MiningModel[0]
         assert mm.MiningSchema is not None, 'Missing mining schema'
-        assert len(mm.MiningSchema.MiningField) == 3, 'Wrong number of mining fields'
+        assert len(mm.MiningSchema.MiningField) == 2, 'Wrong number of mining fields'
         assert mm.Segmentation is not None, 'Missing segmentation root'
 
     def test_transform_with_verification(self):
@@ -46,7 +54,7 @@ class TestGradientBoostingClassifierConverter(TestCase):
         ])
         mm = p.MiningModel[0]
         assert mm.MiningSchema is not None, 'Missing mining schema'
-        assert len(mm.MiningSchema.MiningField) == 3, 'Wrong number of mining fields'
+        assert len(mm.MiningSchema.MiningField) == 2, 'Wrong number of mining fields'
         assert mm.Segmentation is not None, 'Missing segmentation root'
 
 
@@ -58,7 +66,7 @@ class TestGradientBoostingClassifierParity(TestCase, JPMMLClassificationTest):
             JPMMLTest.init_jpmml()
 
     def setUp(self):
-        self.model = GradientBoostingClassifier(n_estimators=2)
+        self.model = GradientBoostingClassifier(n_estimators=2, max_depth=2)
         self.init_data_one_label()
         self.converter = GradientBoostingConverter(
             estimator=self.model,

--- a/sklearn_pmml/convert/test/test_randomForestConverter.py
+++ b/sklearn_pmml/convert/test/test_randomForestConverter.py
@@ -8,6 +8,7 @@ from sklearn.ensemble import RandomForestClassifier
 
 from sklearn_pmml.convert.random_forest import RandomForestClassifierConverter
 
+
 class TestRandomForestClassifierParity(TestCase, JPMMLClassificationTest):
 
     @classmethod
@@ -15,9 +16,11 @@ class TestRandomForestClassifierParity(TestCase, JPMMLClassificationTest):
         if JPMMLTest.can_run():
             JPMMLTest.init_jpmml()
 
-
     def setUp(self):
-        self.model = RandomForestClassifier()
+        self.model = RandomForestClassifier(
+            n_estimators=3,
+            max_depth=3
+        )
         self.init_data()
         self.converter = RandomForestClassifierConverter(
             estimator=self.model,

--- a/sklearn_pmml/convert/test/test_randomForestConverter.py
+++ b/sklearn_pmml/convert/test/test_randomForestConverter.py
@@ -1,6 +1,8 @@
+from sklearn_pmml.convert import StringCategoricalFeature, IntegerCategoricalFeature
+
 __author__ = 'evancox'
 
-from jpmml_test import JPMMLClassificationTest, JPMMLTest
+from jpmml_test import JPMMLClassificationTest, JPMMLTest, TARGET_NAME
 from unittest import TestCase
 
 from sklearn.ensemble import RandomForestClassifier
@@ -26,5 +28,9 @@ class TestRandomForestClassifierParity(TestCase, JPMMLClassificationTest):
             estimator=self.model,
             context=self.ctx
         )
+
+    @property
+    def output(self):
+        return IntegerCategoricalFeature(name=TARGET_NAME, value_list=[0, 1, 2])
 
 

--- a/sklearn_pmml/convert/test/test_randomForestConverter.py
+++ b/sklearn_pmml/convert/test/test_randomForestConverter.py
@@ -1,11 +1,9 @@
-from sklearn_pmml.convert import StringCategoricalFeature, IntegerCategoricalFeature
+from sklearn_pmml.convert import IntegerCategoricalFeature
+from sklearn_pmml.convert.test.jpmml_test import JPMMLClassificationTest, JPMMLTest, TARGET_NAME
+from unittest import TestCase
+from sklearn.ensemble import RandomForestClassifier
 
 __author__ = 'evancox'
-
-from jpmml_test import JPMMLClassificationTest, JPMMLTest, TARGET_NAME
-from unittest import TestCase
-
-from sklearn.ensemble import RandomForestClassifier
 
 
 from sklearn_pmml.convert.random_forest import RandomForestClassifierConverter
@@ -32,5 +30,3 @@ class TestRandomForestClassifierParity(TestCase, JPMMLClassificationTest):
     @property
     def output(self):
         return IntegerCategoricalFeature(name=TARGET_NAME, value_list=[0, 1, 2])
-
-

--- a/sklearn_pmml/convert/tree.py
+++ b/sklearn_pmml/convert/tree.py
@@ -6,7 +6,7 @@ from sklearn.tree._tree import Tree, TREE_LEAF
 import numpy as np
 
 from sklearn_pmml.convert.model import EstimatorConverter, ModelMode, Schema
-from sklearn_pmml.convert.features import Feature, CategoricalFeature, NumericFeature, FeatureOpType, FeatureType
+from sklearn_pmml.convert.features import Feature, CategoricalFeature, NumericFeature
 import sklearn_pmml.pmml as pmml
 from sklearn_pmml.convert.utils import estimator_to_converter
 
@@ -40,6 +40,8 @@ class DecisionTreeConverter(EstimatorConverter):
                 estimator.tree_.value.shape[1], len(self.context.schemas[Schema.OUTPUT]))
 
         # create hidden variables for each categorical output
+        # TODO: this code is copied from the ClassifierConverter. To make things right, we need an abstract tree
+        # TODO: converter and subclasses for classifier and regression converters
         internal_schema = list(filter(lambda x: isinstance(x, CategoricalFeature), self.context.schemas[Schema.OUTPUT]))
         self.context.schemas[Schema.INTERNAL] = internal_schema
 

--- a/sklearn_pmml/convert/tree.py
+++ b/sklearn_pmml/convert/tree.py
@@ -5,8 +5,8 @@ from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from sklearn.tree._tree import Tree, TREE_LEAF
 import numpy as np
 
-from sklearn_pmml.convert.model import EstimatorConverter
-from sklearn_pmml.convert.features import Feature, CategoricalFeature, NumericFeature
+from sklearn_pmml.convert.model import EstimatorConverter, ModelMode, Schema
+from sklearn_pmml.convert.features import Feature, CategoricalFeature, NumericFeature, FeatureOpType, FeatureType
 import sklearn_pmml.pmml as pmml
 from sklearn_pmml.convert.utils import estimator_to_converter
 
@@ -21,41 +21,45 @@ class DecisionTreeConverter(EstimatorConverter):
     def __init__(self, estimator, context, mode):
         super(DecisionTreeConverter, self).__init__(estimator, context, mode)
 
-        assert len(self.context.schemas[self.SCHEMA_OUTPUT]) == 1, 'Only one-label trees are supported'
+        assert len(self.context.schemas[Schema.OUTPUT]) == 1, 'Only one-label trees are supported'
         assert hasattr(estimator, 'tree_'), 'Estimator has no tree_ attribute'
-        if mode == self.MODE_CLASSIFICATION:
-            if isinstance(self.context.schemas[self.SCHEMA_OUTPUT][0], CategoricalFeature):
+        if mode == ModelMode.CLASSIFICATION:
+            if isinstance(self.context.schemas[Schema.OUTPUT][0], CategoricalFeature):
                 self.prediction_output = self.OUTPUT_LABEL
             else:
                 self.prediction_output = self.OUTPUT_PROBABILITY
             assert isinstance(self.estimator, ClassifierMixin), \
                 'Only a classifier can be serialized in classification mode'
-        if mode == self.MODE_REGRESSION:
-            assert isinstance(self.context.schemas[self.SCHEMA_OUTPUT][0], NumericFeature), \
+        if mode == ModelMode.REGRESSION:
+            assert isinstance(self.context.schemas[Schema.OUTPUT][0], NumericFeature), \
                 'Only a numeric feature can be an output of regression'
             assert isinstance(self.estimator, RegressorMixin), \
                 'Only a regressor can be serialized in regression mode'
-        assert estimator.tree_.value.shape[1] == len(self.context.schemas[self.SCHEMA_OUTPUT]), \
+        assert estimator.tree_.value.shape[1] == len(self.context.schemas[Schema.OUTPUT]), \
             'Tree outputs {} results while the schema specifies {} output fields'.format(
-                estimator.tree_.value.shape[1], len(self.context.schemas[self.SCHEMA_OUTPUT]))
+                estimator.tree_.value.shape[1], len(self.context.schemas[Schema.OUTPUT]))
+
+        # create hidden variables for each categorical output
+        internal_schema = list(filter(lambda x: isinstance(x, CategoricalFeature), self.context.schemas[Schema.OUTPUT]))
+        self.context.schemas[Schema.INTERNAL] = internal_schema
 
     def _model(self):
-        assert self.SCHEMA_NUMERIC in self.context.schemas, \
-            'Either build transformation dictionary or provide {} schema in context'.format(self.SCHEMA_NUMERIC)
-        tm = pmml.TreeModel(functionName=self.model_function_name, splitCharacteristic=self.SPLIT_BINARY)
+        assert Schema.NUMERIC in self.context.schemas, \
+            'Either build transformation dictionary or provide {} schema in context'.format(Schema.NUMERIC)
+        tm = pmml.TreeModel(functionName=self.model_function.value, splitCharacteristic=self.SPLIT_BINARY)
         tm.append(self.mining_schema())
         tm.append(self.output())
         tm.Node = self._transform_node(
             self.estimator.tree_,
             self.NODE_ROOT,
-            self.context.schemas[self.SCHEMA_NUMERIC],
-            self.context.schemas[self.SCHEMA_OUTPUT][0]
+            self.context.schemas[Schema.NUMERIC],
+            self.context.schemas[Schema.OUTPUT][0]
         )
         return tm
 
     def model(self, verification_data=None):
-        assert self.SCHEMA_NUMERIC in self.context.schemas, \
-            'Either build transformation dictionary or provide {} schema in context'.format(self.SCHEMA_NUMERIC)
+        assert Schema.NUMERIC in self.context.schemas, \
+            'Either build transformation dictionary or provide {} schema in context'.format(Schema.NUMERIC)
         tm = self._model()
         if verification_data is not None:
             tm.append(self.model_verification(verification_data))
@@ -90,7 +94,7 @@ class DecisionTreeConverter(EstimatorConverter):
                 )
             )
             right_child = self._transform_node(tree, tree.children_right[index], input_schema, output_feature)
-            if self.model_function_name == self.MODE_CLASSIFICATION:
+            if self.model_function == ModelMode.CLASSIFICATION:
                 score, score_prob = None, 0.0
                 for i in range(len(tree.value[index][0])):
                     left_score = left_child.ScoreDistribution[i]
@@ -108,7 +112,7 @@ class DecisionTreeConverter(EstimatorConverter):
 
         else:
             node_value = np.array(tree.value[index][0])
-            if self.model_function_name == self.MODE_CLASSIFICATION:
+            if self.model_function == ModelMode.CLASSIFICATION:
                 probs = node_value / float(node_value.sum())
                 for i in range(len(probs)):
                     node.append(pmml.ScoreDistribution(
@@ -117,15 +121,48 @@ class DecisionTreeConverter(EstimatorConverter):
                         value_=output_feature.from_number(i)
                     ))
                 node.score = output_feature.from_number(probs.argmax())
-            elif self.model_function_name == self.MODE_REGRESSION:
+            elif self.model_function == ModelMode.REGRESSION:
                 node.score = node_value[0]
 
         return node
 
+    def output(self):
+        """
+        Output section of PMML contains all model outputs.
+        Classification tree output contains output variable as a label,
+        and <variable>::<value> as a probability of a value for a variable
+        :return: pmml.Output
+        """
+        output = pmml.Output()
+
+        # the response variables
+        for feature in self.context.schemas[Schema.OUTPUT]:
+            output_field = pmml.OutputField(
+                name=Schema.OUTPUT.extract_feature_name(feature),
+                feature='predictedValue',
+                optype=feature.optype.value,
+                dataType=feature.data_type.value
+            )
+            output.append(output_field)
+
+        # the probabilities for categories; should only be populated for classification jobs
+        for feature in self.context.schemas[Schema.CATEGORIES]:
+            output_field = pmml.OutputField(
+                name=Schema.CATEGORIES.extract_feature_name(feature),
+                optype=feature.optype.value,
+                dataType=feature.data_type.value,
+                feature='probability',
+                targetField=Schema.INTERNAL.extract_feature_name(feature.namespace),
+                value_=feature.name
+            )
+            output.append(output_field)
+
+        return output
+
 
 estimator_to_converter[DecisionTreeClassifier] = partial(
-    DecisionTreeConverter, mode=DecisionTreeConverter.MODE_CLASSIFICATION
+    DecisionTreeConverter, mode=ModelMode.CLASSIFICATION
 )
 estimator_to_converter[DecisionTreeRegressor] = partial(
-    DecisionTreeConverter, mode=DecisionTreeConverter.MODE_REGRESSION
+    DecisionTreeConverter, mode=ModelMode.REGRESSION
 )


### PR DESCRIPTION
Hi all, 
I made a few changes to the way we output results from the resulting PMML model. First of all, now the `varname` outputs the label in the classification task, and `varname::value` outputs the probability to get `value` label. This allows us to deal with multiclass/multilabel models in future
Also, the `TransformationContext` API was changed a bit, and all the schema names were extracted to the single enum.
